### PR TITLE
启动时，更新openai和pillow库超时问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def init_db():
 
 def ensure_dependencies():
     import pkg.utils.pkgmgr as pkgmgr
-    pkgmgr.run_pip(["install", "openai", "Pillow", "--upgrade"])
+    pkgmgr.run_pip(["install", "openai", "Pillow", "--upgrade", "-i", "https://pypi.douban.com/simple/"])
 
 
 known_exception_caught = False

--- a/main.py
+++ b/main.py
@@ -45,7 +45,9 @@ def init_db():
 
 def ensure_dependencies():
     import pkg.utils.pkgmgr as pkgmgr
-    pkgmgr.run_pip(["install", "openai", "Pillow", "--upgrade", "-i", "https://pypi.douban.com/simple/"])
+    pkgmgr.run_pip(["install", "openai", "Pillow", "--upgrade",
+                    "-i", "https://pypi.douban.com/simple/",
+                    "--trusted-host", "pypi.douban.com"])
 
 
 known_exception_caught = False


### PR DESCRIPTION
主要改动如下：
1、在ensure_dependencies函数更更新包时，出现超时的情况，指定更新源 https://pypi.douban.com/simple/