### PR TITLE
feat: 支持json格式的配置文件 (#265)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ temp/
 current_tag
 scenario/
 !scenario/default-template.json
+override.json

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import os
 import shutil
 import threading
@@ -143,9 +144,22 @@ def main(first_time_init=False):
                 setattr(config, key, getattr(config_template, key))
                 logging.warning("[{}]不存在".format(key))
                 is_integrity = False
+
         if not is_integrity:
             logging.warning("配置文件不完整，请依据config-template.py检查config.py")
             logging.warning("以上配置已被设为默认值，将在5秒后继续启动... ")
+
+        # 检查override.json覆盖
+        if os.path.exists("override.json"):
+            override_json = json.load(open("override.json", "r", encoding="utf-8"))
+            for key in override_json:
+                if hasattr(config, key):
+                    setattr(config, key, override_json[key])
+                    logging.info("覆写配置[{}]为[{}]".format(key, override_json[key]))
+                else:
+                    logging.error("无法覆写配置[{}]为[{}]，该配置不存在，请检查override.json是否正确".format(key, override_json[key]))
+
+        if not is_integrity:
             time.sleep(5)
 
         import pkg.utils.context


### PR DESCRIPTION
支持在config.py同目录建立`override.json`以使用json格式覆写config.py的配置项内容，例如:
```JSON
{
    "admin_qq": 12345678
}
```
这样程序将忽略config.py中设置的`admin_qq`值，转而使用此文件中指定的`12345678`为`admin_qq`的值，所有字段均支持，可以查看`config-template.py`  

同样的，数组和字典也受支持，但要注意以json的语法编写，`true`及`false`也请使用json的格式