### PR TITLE
修复usage命令的代理问题

### DIFF
--- a/pkg/qqbot/command.py
+++ b/pkg/qqbot/command.py
@@ -284,7 +284,8 @@ def process_command(session_name: str, text_message: str, mgr, config,
                                                                             int(image_count))
                 # 获取此key的额度
                 try:
-                    credit_data = credit.fetch_credit_data(api_keys[key_name])
+                    http_proxy = config.openai_config["http_proxy"] if "http_proxy" in config.openai_config else None
+                    credit_data = credit.fetch_credit_data(api_keys[key_name], http_proxy)
                     reply_str += " - 使用额度:{:.2f}/{:.2f}\n".format(credit_data['total_used'],credit_data['total_granted'])
                 except Exception as e:
                     logging.warning("获取额度失败:{}".format(e))

--- a/pkg/utils/credit.py
+++ b/pkg/utils/credit.py
@@ -1,13 +1,19 @@
 # OpenAI账号免费额度剩余查询
 import requests
 
-
-def fetch_credit_data(api_key: str) -> dict:
+def fetch_credit_data(api_key: str, http_proxy: str) -> dict:
     """OpenAI账号免费额度剩余查询"""
+    proxies = {
+        "http":http_proxy,
+        "https":http_proxy
+    } if http_proxy is not None else None
+
     resp = requests.get(
         url="https://api.openai.com/dashboard/billing/credit_grants",
         headers={
             "Authorization": "Bearer {}".format(api_key),
-        }
+        },
+        proxies=proxies
     )
+
     return resp.json()


### PR DESCRIPTION
BUG描述：当配置代理时，!usage命令无法读取到代理参数，导致直连请求，最后超时
修复内容：在**pkg/qqbot/command.py**内，调用**pkg/utils/credit.py**的**fetch_credit_data**时，将config内的代理参数传入，并携带代理参数进行请求，要注意proxies参数默认为proxies=None，而不是proxies={None}