### PR TITLE
[Feat] 完善情景预设相关内容

### DIFF
--- a/config-template.py
+++ b/config-template.py
@@ -80,8 +80,8 @@ default_prompt = {
 }
 
 # 情景预设格式
-# 参考值：旧版本方式：default | 完整情景：full_scenario
-# 旧版本的格式为上述default_prompt中的内容，或prompts目录下的文件名
+# 参考值：默认方式：normal | 完整情景：full_scenario
+# 默认的格式为上述default_prompt中的内容，或prompts目录下的文件名
 #
 # 完整情景预设的格式为JSON，在scenario目录下的JSON文件中列出对话的每个回合，编写方法见scenario/default-template.json
 # 编写方法例如：
@@ -106,7 +106,7 @@ default_prompt = {
 # 您可以按照上述格式编写自己的情景预设，在prompt中列出对话的每个回合，
 # role为user或assistant，分别表示用户和机器人的回复
 # 每个JSON文件是一个情景预设，文件名即为情景预设的名称
-preset_mode = "default"
+preset_mode = "normal"
 
 # 群内响应规则
 # 符合此消息的群内消息即使不包含at机器人也会响应

--- a/main.py
+++ b/main.py
@@ -191,9 +191,8 @@ def start(first_time_init=False):
         import pkg.openai.session
         import pkg.qqbot.manager
         import pkg.openai.dprompt
-
-        pkg.openai.dprompt.read_prompt_from_file()
-        pkg.openai.dprompt.read_scenario_from_file()
+        
+        pkg.openai.dprompt.register_all()
 
         # 主启动流程
         database = pkg.database.manager.DatabaseManager()

--- a/override-all.json
+++ b/override-all.json
@@ -17,7 +17,7 @@
     "default_prompt": {
         "default": "如果我之后想获取帮助，请你说“输入!help获取帮助”"
     },
-    "preset_mode": "default",
+    "preset_mode": "normal",
     "response_rules": {
         "at": true,
         "prefix": [
@@ -42,7 +42,7 @@
     "baidu_secret_key": "",
     "inappropriate_message_tips": "[百度云]请珍惜机器人，当前返回内容不合规",
     "encourage_sponsor_at_start": true,
-    "prompt_submit_length": 1024,
+    "prompt_submit_length": 2048,
     "completion_api_params": {
         "model": "gpt-3.5-turbo",
         "temperature": 0.9,
@@ -63,7 +63,9 @@
     "retry_times": 3,
     "hide_exce_info_to_user": false,
     "alter_tip_message": "出错了，请稍后再试",
-    "pool_num": 10,
+    "sys_pool_num": 8,
+    "admin_pool_num": 2,
+    "user_pool_num": 6,
     "session_expire_time": 1200,
     "rate_limitation": 60,
     "rate_limit_strategy": "wait",

--- a/pkg/openai/dprompt.py
+++ b/pkg/openai/dprompt.py
@@ -101,7 +101,7 @@ def get_prompt(name: str = None) -> list:
                 return __scenario_from_files__[key]['prompt']
         
     # 默认预设方式
-    elif preset_mode == 'default':
+    elif preset_mode == 'default' or preset_mode == 'normal':
 
         default_dict = get_prompt_dict()
 

--- a/pkg/openai/session.py
+++ b/pkg/openai/session.py
@@ -141,9 +141,9 @@ class Session:
         import pkg.openai.dprompt as dprompt
 
         if use_default is None:
-            use_default = dprompt.get_current()
+            use_default = dprompt.mode_inst().get_using_name()
 
-        current_default_prompt = dprompt.get_prompt(use_default)
+        current_default_prompt, _ = dprompt.mode_inst().get_prompt(use_default)
         return current_default_prompt
 
     def __init__(self, name: str):

--- a/pkg/qqbot/cmds/session.py
+++ b/pkg/qqbot/cmds/session.py
@@ -234,13 +234,13 @@ def cmd_default(cmd: str, params: list, session_name: str,
         # 输出目前所有情景预设
         import pkg.openai.dprompt as dprompt
         reply_str = "[bot]当前所有情景预设:\n\n"
-        for key,value in dprompt.get_prompt_dict().items():
-            reply_str += "  - {}: {}\n".format(key,value)
+        for key, value in dprompt.get_prompt_dict().items():
+            reply_str += "  - {}: {}\n".format(key, value)
 
         reply_str += "\n当前默认情景预设:{}\n".format(dprompt.get_current())
         reply_str += "请使用!default <情景预设>来设置默认情景预设"
         reply = [reply_str]
-    elif len(params) >0  and is_admin:
+    elif len(params) > 0 and is_admin:
         # 设置默认情景
         import pkg.openai.dprompt as dprompt
         try:


### PR DESCRIPTION
## 概述

- [x] 重命名`reset_mode`的`default`选项为`normal`，以区分其他使用到`default`的地方
- [x] 使用策略模式重构有关情景预设两种模式的所有操作
- [x] 修复 #289 

### 事务

- [x] 已阅读仓库[贡献指引](../CONTRIBUTING.md)
- [x] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 暂无
