### PR TITLE
Update docker_deploy.md

### DIFF
--- a/docker_deploy.md
+++ b/docker_deploy.md
@@ -17,7 +17,7 @@
 #### 2.1 输入指令
 
 ```
-docker run -d -it -p 8080:8080 --name mcl --network host -v ./qq/plugins:/app/plugins -v ./qq/config:/app/config -v   ./qq/data:/app/data -v ./qq/bots:/app/bots --restart unless-stopped kagurazakanyaa/mcl:latest
+docker run -d -it --name mcl --network host -v ${PWD}/qq/plugins:/app/plugins -v ${PWD}/qq/config:/app/config -v   ${PWD}/qq/data:/app/data -v ${PWD}/qq/bots:/app/bots --restart unless-stopped kagurazakanyaa/mcl:latest
 ```
 
 这里使用了[KagurazakaNyaa/mirai-console-loader-docker](https://github.com/KagurazakaNyaa/mirai-console-loader-docker)的镜像
@@ -60,7 +60,7 @@ adapterSettings:
 
 `verifyKey`要求与`bot`的`config.py`中的`verifyKey`相同
 
- `port`: 8080要和2.1输入指令的端口号相同
+ `port`: 8080要和2.4 config.py配置里面的端口号相同
 
 #### 2.4 登录
 
@@ -87,9 +87,9 @@ autologin setConfig <机器人QQ号> protocol ANDROID_PAD
 
 ### 3. 部署QChatGPT
 
-配置好config.py,运行下面的
+配置好config.py,保存到当前目录下,运行下面的
 
 ```
- docker run  -it -p 8080:8080  --name mcl   --network host   -v ${PWD}/:/QChatGPT  mikumifa/qchatgpt-docker
+ docker run  -it -d --name QChatGPT   --network host   -v ${PWD}/config.py:/QChatGPT/config.py  mikumifa/qchatgpt-docker
 ```
 


### PR DESCRIPTION
2.1中 `network host` 就是开放容器内的所有端口，和 `-p 端口：端口` 不共用
2.1中  `-v ./qq/xxx` 在群晖中不能用，改成了`${PWD}/qq/xxx`
3 中 容器名和上面的重复了，映射整个目录会无法运行，改成只映射 config.py

以上是我docker部署中遇到的问题及修改

## 概述

实现/解决/优化的内容: 

### 事务

- [ ] 已阅读仓库[贡献指引](../CONTRIBUTING.md)
- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [ ] 已编写完善的配置文件字段说明（若有新增）
- [ ] 已编写面向用户的新功能说明（若有必要）
- [ ] 已测试新功能或更改

### 兼容性

- [ ] 已处理版本兼容性
- [ ] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
