### PR TITLE
Create build_docker_image.yml

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,29 @@
+name: Build Image
+on:
+  #防止fork乱用action设置只能手动触发构建
+  workflow_dispatch:
+  ## 发布release的时候会自动构建
+  release:
+    types: [published]
+jobs:
+  build:
+      runs-on: ubuntu-latest
+      name: Build image job
+      
+      steps:
+          - name: Checkout master
+            uses: actions/checkout@master
+          - name: Get version
+            id: get_version
+            if: startsWith(github.ref, 'refs/tags/') && startsWith(github.repository, 'RockChinQ/QChatGPT')
+            run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+          - name: Build and publish image
+            uses: ilteoood/docker_buildx@master
+            if: startsWith(github.ref, 'refs/tags/') && startsWith(github.repository, 'RockChinQ/QChatGPT')
+            with:
+              publish: true
+              imageName: mikumifa/qchatgpt-docker # dockerid/imageName
+              platform: linux/386,linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7 # 你准备构建的镜像平台
+              tag: latest,${{ steps.get_version.outputs.VERSION }}
+              dockerUser: ${{ secrets.DOCKER_USERNAME }} # docker hub userid 在setting创建secrets name=DOCKER_USERNAME  value=dockerid
+              dockerPassword: ${{ secrets.DOCKER_PASSWORD }} # docker hub password,在setting创建secrets name=DOCKER_PASSWORD  value=dockerpassword


### PR DESCRIPTION
利用github action 自动构建docker镜像：
## 1、
`workflow_dispatch:` 是需要作者在action手动点击进行构建

```
  release:
    types: [published]
```
这个是发布release的时候自动构建镜像。根据作者需求启用或者删除注释掉

## 2、
`tag: latest,${{ steps.get_version.outputs.VERSION }}`是可以镜像打标为latest和release发布的版本号

## 3、
docker hub userid 在setting创建secrets， name=DOCKER_USERNAME   value=dockerid
docker hub password,在setting创建secrets， name=DOCKER_PASSWORD   value=dockerpassword

这样作者就不用在自己机器上构建docker镜像，利用action 自动完成全平台镜像 速度也快。

## 概述

实现/解决/优化的内容: 

### 事务

- [x] 已阅读仓库[贡献指引](../CONTRIBUTING.md)
- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [ ] 已编写完善的配置文件字段说明（若有新增）
- [ ] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [ ] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
