### PR TITLE
[Feat] 支持使用!cfg指令修改子配置项

### DIFF
--- a/pkg/qqbot/cmds/system/cconfig.py
+++ b/pkg/qqbot/cmds/system/cconfig.py
@@ -8,7 +8,7 @@ def config_operation(cmd, params):
     config = pkg.utils.context.get_config()
     reply_str = ""
     if len(params) == 0:
-        reply = ["[bot]err:请输入配置项"]
+        reply = ["[bot]err:请输入!cmd cfg查看使用方法"]
     else:
         cfg_name = params[0]
         if cfg_name == 'all':
@@ -26,45 +26,60 @@ def config_operation(cmd, params):
                     else:
                         reply_str += "{}: {}\n".format(cfg, getattr(config, cfg))
             reply = [reply_str]
-        elif cfg_name in dir(config):
-            if len(params) == 1:
-                # 按照配置项类型进行格式化
-                if isinstance(getattr(config, cfg_name), str):
-                    reply_str = "[bot]配置项{}: \"{}\"\n".format(cfg_name, getattr(config, cfg_name))
-                elif isinstance(getattr(config, cfg_name), dict):
-                    reply_str = "[bot]配置项{}: {}\n".format(cfg_name,
-                                                             json.dumps(getattr(config, cfg_name),
-                                                                        ensure_ascii=False, indent=4))
-                else:
-                    reply_str = "[bot]配置项{}: {}\n".format(cfg_name, getattr(config, cfg_name))
-                reply = [reply_str]
-            else:
-                cfg_value = " ".join(params[1:])
-                # 类型转换，如果是json则转换为字典
-                if cfg_value == 'true':
-                    cfg_value = True
-                elif cfg_value == 'false':
-                    cfg_value = False
-                elif cfg_value.isdigit():
-                    cfg_value = int(cfg_value)
-                elif cfg_value.startswith('{') and cfg_value.endswith('}'):
-                    cfg_value = json.loads(cfg_value)
-                else:
-                    try:
-                        cfg_value = float(cfg_value)
-                    except ValueError:
-                        pass
-
-                # 检查类型是否匹配
-                if isinstance(getattr(config, cfg_name), type(cfg_value)):
-                    setattr(config, cfg_name, cfg_value)
-                    pkg.utils.context.set_config(config)
-                    reply = ["[bot]配置项{}修改成功".format(cfg_name)]
-                else:
-                    reply = ["[bot]err:配置项{}类型不匹配".format(cfg_name)]
-
         else:
-            reply = ["[bot]err:未找到配置项 {}".format(cfg_name)]
+            cfg_entry_path = cfg_name.split('.')
+
+            try:
+                if len(params) == 1:
+                    cfg_entry = getattr(config, cfg_entry_path[0])
+                    if len(cfg_entry_path) > 1:
+                        for i in range(1, len(cfg_entry_path)):
+                            cfg_entry = cfg_entry[cfg_entry_path[i]]
+
+                    if isinstance(cfg_entry, str):
+                        reply_str = "[bot]配置项{}: \"{}\"\n".format(cfg_name, cfg_entry)
+                    elif isinstance(cfg_entry, dict):
+                        reply_str = "[bot]配置项{}: {}\n".format(cfg_name,
+                                                                 json.dumps(cfg_entry,
+                                                                            ensure_ascii=False, indent=4))
+                    else:
+                        reply_str = "[bot]配置项{}: {}\n".format(cfg_name, cfg_entry)
+                    reply = [reply_str]
+                else:
+                    cfg_value = " ".join(params[1:])
+                    # 类型转换，如果是json则转换为字典
+                    if cfg_value == 'true':
+                        cfg_value = True
+                    elif cfg_value == 'false':
+                        cfg_value = False
+                    elif cfg_value.isdigit():
+                        cfg_value = int(cfg_value)
+                    elif cfg_value.startswith('{') and cfg_value.endswith('}'):
+                        cfg_value = json.loads(cfg_value)
+                    else:
+                        try:
+                            cfg_value = float(cfg_value)
+                        except ValueError:
+                            pass
+
+                    cfg_entry = getattr(config, cfg_entry_path[0])
+                    if len(cfg_entry_path) > 1:
+                        for i in range(1, len(cfg_entry_path) - 1):
+                            cfg_entry = cfg_entry[cfg_entry_path[i]]
+                        if isinstance(cfg_entry[cfg_entry_path[-1]], type(cfg_value)):
+                            cfg_entry[cfg_entry_path[-1]] = cfg_value
+                            reply = ["[bot]配置项{}修改成功".format(cfg_name)]
+                        else:
+                            reply = ["[bot]err:配置项{}类型不匹配".format(cfg_name)]
+                    else:
+                        setattr(config, cfg_entry_path[0], cfg_value)
+                        reply = ["[bot]配置项{}修改成功".format(cfg_name)]
+            except AttributeError:
+                reply = ["[bot]err:未找到配置项 {}".format(cfg_name)]
+            except ValueError:
+                reply = ["[bot]err:未找到配置项 {}".format(cfg_name)]
+        # else:
+        #     reply = ["[bot]err:未找到配置项 {}".format(cfg_name)]
 
     return reply
 

--- a/pkg/qqbot/cmds/system/cconfig.py
+++ b/pkg/qqbot/cmds/system/cconfig.py
@@ -48,19 +48,20 @@ def config_operation(cmd, params):
                 else:
                     cfg_value = " ".join(params[1:])
                     # 类型转换，如果是json则转换为字典
-                    if cfg_value == 'true':
-                        cfg_value = True
-                    elif cfg_value == 'false':
-                        cfg_value = False
-                    elif cfg_value.isdigit():
-                        cfg_value = int(cfg_value)
-                    elif cfg_value.startswith('{') and cfg_value.endswith('}'):
-                        cfg_value = json.loads(cfg_value)
-                    else:
-                        try:
-                            cfg_value = float(cfg_value)
-                        except ValueError:
-                            pass
+                    # if cfg_value == 'true':
+                    #     cfg_value = True
+                    # elif cfg_value == 'false':
+                    #     cfg_value = False
+                    # elif cfg_value.isdigit():
+                    #     cfg_value = int(cfg_value)
+                    # elif cfg_value.startswith('{') and cfg_value.endswith('}'):
+                    #     cfg_value = json.loads(cfg_value)
+                    # else:
+                    #     try:
+                    #         cfg_value = float(cfg_value)
+                    #     except ValueError:
+                    #         pass
+                    cfg_value = eval(cfg_value)
 
                     cfg_entry = getattr(config, cfg_entry_path[0])
                     if len(cfg_entry_path) > 1:

--- a/res/wiki/功能使用.md
+++ b/res/wiki/功能使用.md
@@ -225,7 +225,7 @@
 格式: `!cfg <配置项名称> <配置项新值>`  
 以修改`default_prompt`示例
 ```
-!cfg default_prompt 我是Rock Chin
+!cfg default_prompt "我是Rock Chin"
 ```
 
 输出示例
@@ -243,7 +243,15 @@
 ```
 !~all
 !~default_prompt
-!~default_prompt 我是Rock Chin
+!~default_prompt "我是Rock Chin"
+```
+
+5. 配置项名称支持使用点号(.)拼接以索引子配置项
+
+例如: `openai_config.api_key`将索引`config`字典中的`openai_config`字典中的`api_key`字段，可以通过这个方式查看或修改此子配置项
+
+```
+!~openai_config.api_key
 ```
 
 </details>


### PR DESCRIPTION
## 概述

rt

### 事务

- [x] 已阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)
- [x] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 

现在修改字符串类型的配置项时，需要使用英文双引号（或英文单引号）包括其值