### PR TITLE
加入one-api项目支持的国内大模型

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 </div>
 
 > **NOTE**  
+> 2023/9/13 现已支持通过[One API](https://github.com/songquanpeng/one-api)接入 Azure、Anthropic Claude、Google PaLM 2、智谱 ChatGLM、百度文心一言、讯飞星火认知、阿里通义千问以及 360 智脑等模型，欢迎测试并反馈。  
 > 2023/8/29 [逆向库插件](https://github.com/RockChinQ/revLibs)已支持 gpt4free  
 > 2023/8/14 [逆向库插件](https://github.com/RockChinQ/revLibs)已支持Claude和Bard  
 > 2023/7/29 支持使用GPT的Function Calling功能实现类似ChatGPT Plugin的效果，请见[Wiki内容函数](https://github.com/RockChinQ/QChatGPT/wiki/6-%E6%8F%92%E4%BB%B6%E4%BD%BF%E7%94%A8-%E5%86%85%E5%AE%B9%E5%87%BD%E6%95%B0)  

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@
 
 ### 模型聚合平台
 
-- gpt4free, 免费使用多个平台的各种文字模型, 由[插件](https://github.com/RockChinQ/revLibs)接入, 无需鉴权, 稳定性较差
-- poe.com, 免费使用Poe上多个平台的模型, 由[oliverkirk-sudo/ChatPoeBot](https://github.com/oliverkirk-sudo/ChatPoeBot)接入
+- [One API](https://github.com/songquanpeng/one-api), Azure、Anthropic Claude、Google PaLM 2、智谱 ChatGLM、百度文心一言、讯飞星火认知、阿里通义千问以及 360 智脑等模型的官方接口转换成 OpenAI API 接入，QChatGPT 原生支持，您需要先配置 One API，之后在`config.py`中设置反向代理和`One API`的密钥后使用。
+- [gpt4free](https://github.com/xtekky/gpt4free), 破解以免费使用多个平台的各种文字模型, 由[插件](https://github.com/RockChinQ/revLibs)接入, 无需鉴权, 稳定性较差。
+- [Poe](https://poe.com), 破解免费使用Poe上多个平台的模型, 由[oliverkirk-sudo/ChatPoeBot](https://github.com/oliverkirk-sudo/ChatPoeBot)接入（由于 Poe 上可用的大部分模型现已通过[revLibs插件](https://github.com/RockChinQ/revLubs)或其他方式接入，此插件现已停止维护）。
 
 ### 故事续写
 

--- a/pkg/openai/modelmgr.py
+++ b/pkg/openai/modelmgr.py
@@ -32,7 +32,15 @@ CHAT_COMPLETION_MODELS = {
     'gpt-4',
     'gpt-4-0613',
     'gpt-4-32k',
-    'gpt-4-32k-0613'
+    'gpt-4-32k-0613',
+    'SparkDesk',
+    'chatglm_pro',
+    'chatglm_std',
+    'chatglm_lite',
+    'qwen-v1',
+    'qwen-plus-v1',
+    'ERNIE-Bot',
+    'ERNIE-Bot-turbo',
 }
 
 EDIT_MODELS = {
@@ -66,6 +74,14 @@ def count_chat_completion_tokens(messages: list, model: str) -> int:
         "gpt-4-32k-0314",
         "gpt-4-0613",
         "gpt-4-32k-0613",
+        "SparkDesk",
+        "chatglm_pro",
+        "chatglm_std",
+        "chatglm_lite",
+        "qwen-v1",
+        "qwen-plus-v1",
+        "ERNIE-Bot",
+        "ERNIE-Bot-turbo",
         }:
         tokens_per_message = 3
         tokens_per_name = 1

--- a/pkg/openai/modelmgr.py
+++ b/pkg/openai/modelmgr.py
@@ -33,6 +33,7 @@ CHAT_COMPLETION_MODELS = {
     'gpt-4-0613',
     'gpt-4-32k',
     'gpt-4-32k-0613',
+    # One-API 接入
     'SparkDesk',
     'chatglm_pro',
     'chatglm_std',


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 

one-api是一个api整合项目，通过这个项目的反代理，可以像使用gpt系列的/v1/completion接口一样调用国内的大模型，仅仅需要更改一下模型名字。

项目地址：https://github.com/songquanpeng/one-api

因而，仅仅在chatcompletion这个类中加入one-api项目支持的国内模型即可以调用国内大模型。

目前接入的one-api渠道的模型有：讯飞星火大模型(因为不支持stream模式目前无法使用，one-api渠道即将更新，所以先接入了)、智谱ChatGLM、阿里通义千问、百度文心千帆

希望作者大大能在readme中说明下要接入one-api才能用这些模型，同时，我还向switcher插件提交了相应的pull，需要一并整合介绍。

### 事务

- [x] 已阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)
- [x] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 无
