### PR TITLE
Feat: 通过 GitHub API 进行插件安装和更新

### DIFF
--- a/.github/workflows/update-cmdpriv-template.yml
+++ b/.github/workflows/update-cmdpriv-template.yml
@@ -21,12 +21,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: 3.10.13
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade  yiri-mirai openai colorlog func_timeout dulwich Pillow CallingGPT tiktoken
+        python -m pip install --upgrade  yiri-mirai openai>=1.0.0 colorlog func_timeout dulwich Pillow CallingGPT tiktoken
+        python -m pip install -U openai>=1.0.0
 
     - name: Copy Scripts
       run: |

--- a/.github/workflows/update-override-all.yml
+++ b/.github/workflows/update-override-all.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # 在此处添加您的项目所需的其他依赖
 
       - name: Copy Scripts
         run: |

--- a/pkg/plugin/host.py
+++ b/pkg/plugin/host.py
@@ -70,6 +70,8 @@ def generate_plugin_order():
 def iter_plugins():
     """按照顺序迭代插件"""
     for plugin_name in __plugins_order__:
+        if plugin_name not in __plugins__:
+            continue
         yield __plugins__[plugin_name]
 
 

--- a/pkg/plugin/metadata.py
+++ b/pkg/plugin/metadata.py
@@ -1,0 +1,87 @@
+import os
+import shutil
+import json
+import time
+
+import dulwich.errors as dulwich_err
+
+from ..utils import updater
+
+
+def read_metadata_file() -> dict:
+    # 读取 plugins/metadata.json 文件
+    if not os.path.exists('plugins/metadata.json'):
+        return {}
+    with open('plugins/metadata.json', 'r') as f:
+        return json.load(f)
+
+
+def write_metadata_file(metadata: dict):
+    if not os.path.exists('plugins'):
+        os.mkdir('plugins')
+
+    with open('plugins/metadata.json', 'w') as f:
+        json.dump(metadata, f, indent=4, ensure_ascii=False)
+
+
+def do_plugin_git_repo_migrate():
+    # 仅在 plugins/metadata.json 不存在时执行
+    if os.path.exists('plugins/metadata.json'):
+        return
+
+    metadata = read_metadata_file()
+
+    # 遍历 plugins 下所有目录，获取目录的git远程地址
+    for plugin_name in os.listdir('plugins'):
+        plugin_path = os.path.join('plugins', plugin_name)
+        if not os.path.isdir(plugin_path):
+            continue
+        
+        remote_url = None
+        try:
+            remote_url = updater.get_remote_url(plugin_path)
+        except dulwich_err.NotGitRepository:
+            continue
+        if remote_url == "https://github.com/RockChinQ/QChatGPT" or remote_url == "https://gitee.com/RockChin/QChatGPT" \
+            or remote_url == "" or remote_url is None or remote_url == "http://github.com/RockChinQ/QChatGPT" or remote_url == "http://gitee.com/RockChin/QChatGPT":
+            continue
+
+        from . import host
+
+        if plugin_name not in metadata:
+            metadata[plugin_name] = {
+                'source': remote_url,
+                'install_timestamp': int(time.time()),
+                'ref': 'HEAD',
+            }
+
+    write_metadata_file(metadata)
+    
+
+def set_plugin_metadata(
+    plugin_name: str,
+    source: str,
+    install_timestamp: int,
+    ref: str,
+):
+    metadata = read_metadata_file()
+    metadata[plugin_name] = {
+        'source': source,
+        'install_timestamp': install_timestamp,
+        'ref': ref,
+    }
+    write_metadata_file(metadata)
+
+
+def remove_plugin_metadata(plugin_name: str):
+    metadata = read_metadata_file()
+    if plugin_name in metadata:
+        del metadata[plugin_name]
+        write_metadata_file(metadata)
+
+
+def get_plugin_metadata(plugin_name: str) -> dict:
+    metadata = read_metadata_file()
+    if plugin_name in metadata:
+        return metadata[plugin_name]
+    return {}

--- a/pkg/qqbot/cmds/plugin/plugin.py
+++ b/pkg/qqbot/cmds/plugin/plugin.py
@@ -84,7 +84,7 @@ class PluginGetCommand(AbstractCommandNode):
 @AbstractCommandNode.register(
     parent=PluginCommand,
     name="update",
-    description="更新插件",
+    description="更新指定插件或全部插件",
     usage="!plugin update",
     aliases=[],
     privilege=2

--- a/pkg/qqbot/cmds/plugin/plugin.py
+++ b/pkg/qqbot/cmds/plugin/plugin.py
@@ -84,7 +84,7 @@ class PluginGetCommand(AbstractCommandNode):
 @AbstractCommandNode.register(
     parent=PluginCommand,
     name="update",
-    description="更新所有插件",
+    description="更新插件",
     usage="!plugin update",
     aliases=[],
     privilege=2
@@ -110,7 +110,9 @@ class PluginUpdateCommand(AbstractCommandNode):
                             plugin_host.update_plugin(key)
                             updated.append(key)
                     else:
-                        if ctx.crt_params[0] in plugin_list:
+                        plugin_path_name = plugin_host.get_plugin_path_name_by_plugin_name(ctx.crt_params[0])
+
+                        if ctx.crt_params[0] is not None:
                             plugin_host.update_plugin(ctx.crt_params[0])
                             updated.append(ctx.crt_params[0])
                         else:
@@ -119,7 +121,7 @@ class PluginUpdateCommand(AbstractCommandNode):
                     pkg.utils.context.get_qqbot_manager().notify_admin("已更新插件: {}, 请发送 !reload 重载插件".format(", ".join(updated)))
                 except Exception as e:
                     logging.error("插件更新失败:{}".format(e))
-                    pkg.utils.context.get_qqbot_manager().notify_admin("插件更新失败:{} 请尝试手动更新插件".format(e))
+                    pkg.utils.context.get_qqbot_manager().notify_admin("插件更新失败:{} 请使用 !plugin 命令确认插件名称或尝试手动更新插件".format(e))
 
             reply = ["[bot]正在更新插件，请勿重复发起..."]
             threading.Thread(target=closure).start()

--- a/pkg/qqbot/cmds/plugin/plugin.py
+++ b/pkg/qqbot/cmds/plugin/plugin.py
@@ -112,7 +112,7 @@ class PluginUpdateCommand(AbstractCommandNode):
                     else:
                         plugin_path_name = plugin_host.get_plugin_path_name_by_plugin_name(ctx.crt_params[0])
 
-                        if ctx.crt_params[0] is not None:
+                        if plugin_path_name is not None:
                             plugin_host.update_plugin(ctx.crt_params[0])
                             updated.append(ctx.crt_params[0])
                         else:

--- a/pkg/qqbot/sources/nakuru.py
+++ b/pkg/qqbot/sources/nakuru.py
@@ -185,7 +185,11 @@ class NakuruProjectAdapter(MessageSourceAdapter):
         if resp.status_code == 403:
             logging.error("go-cqhttp拒绝访问，请检查config.py中nakuru_config的token是否与go-cqhttp设置的access-token匹配")
             raise Exception("go-cqhttp拒绝访问，请检查config.py中nakuru_config的token是否与go-cqhttp设置的access-token匹配")
-        self.bot_account_id = int(resp.json()['data']['user_id'])
+        try:
+            self.bot_account_id = int(resp.json()['data']['user_id'])
+        except Exception as e:
+            logging.error("获取go-cqhttp账号信息失败: {}, 请检查是否已启动go-cqhttp并配置正确".format(e))
+            raise Exception("获取go-cqhttp账号信息失败: {}, 请检查是否已启动go-cqhttp并配置正确".format(e))
 
     def send_message(
         self,

--- a/tests/repo_regexp_test.py
+++ b/tests/repo_regexp_test.py
@@ -1,0 +1,7 @@
+import re
+
+repo_url = "git@github.com:RockChinQ/WebwlkrPlugin.git"
+
+repo =  re.findall(r'(?:https?://github\.com/|git@github\.com:)([^/]+/[^/]+?)(?:\.git|/|$)', repo_url)
+
+print(repo)


### PR DESCRIPTION
## 概述

改为使用 GitHub 直接下载源码的形式安装插件，并将插件源地址保存到 `plugins/metadata.json` 中，在更新插件时使用此文件中存储的插件源地址进行最新版本重新安装。

### 事务

- [x] 已阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)
- [x] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

