### PR TITLE
Fix: openai>=1.0时绘图命令不兼容

### DIFF
--- a/config-template.py
+++ b/config-template.py
@@ -260,9 +260,13 @@ completion_api_params = {
 }
 
 # OpenAI的Image API的参数
-# 具体请查看OpenAI的文档: https://beta.openai.com/docs/api-reference/images/create
+# 具体请查看OpenAI的文档: https://platform.openai.com/docs/api-reference/images/create
 image_api_params = {
-    "size": "256x256",  # 图片尺寸，支持256x256, 512x512, 1024x1024
+    "model": "dall-e-2", # 默认使用 dall-e-2 模型，也可以改为 dall-e-3
+    # 图片尺寸
+    # dall-e-2 模型支持 256x256, 512x512, 1024x1024
+    # dall-e-3 模型支持 1024x1024, 1792x1024, 1024x1792
+    "size": "256x256",
 }
 
 # 跟踪函数调用

--- a/override-all.json
+++ b/override-all.json
@@ -60,6 +60,7 @@
         "temperature": 0.9
     },
     "image_api_params": {
+        "model": "dall-e-2",
         "size": "256x256"
     },
     "trace_function_calls": false,

--- a/pkg/openai/manager.py
+++ b/pkg/openai/manager.py
@@ -1,6 +1,7 @@
 import logging
 
 import openai
+from openai.types import images_response
 
 from ..openai import keymgr
 from ..utils import context
@@ -65,7 +66,7 @@ class OpenAIInteract:
 
             yield resp
 
-    def request_image(self, prompt) -> dict:
+    def request_image(self, prompt) -> images_response.ImagesResponse:
         """请求图片接口回复
 
         Parameters:
@@ -77,7 +78,7 @@ class OpenAIInteract:
         config = context.get_config_manager().data
         params = config['image_api_params']
 
-        response = openai.Image.create(
+        response = self.client.images.generate(
             prompt=prompt,
             n=1,
             **params

--- a/pkg/qqbot/cmds/funcs/draw.py
+++ b/pkg/qqbot/cmds/funcs/draw.py
@@ -29,7 +29,7 @@ class DrawCommand(aamgr.AbstractCommandNode):
             res = session.draw_image(" ".join(ctx.params))
 
             logging.debug("draw_image result:{}".format(res))
-            reply = [mirai.Image(url=res['data'][0]['url'])]
+            reply = [mirai.Image(url=res.data[0].url)]
             config = context.get_config_manager().data
             if config['include_image_description']:
                 reply.append(" ".join(ctx.params))


### PR DESCRIPTION
## 概述

修复适配新版 openai 库之后 绘图命令无法使用的问题

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

