### PR TITLE
修复aiocqhttp的图片错误

### DIFF
--- a/pkg/platform/sources/aiocqhttp.py
+++ b/pkg/platform/sources/aiocqhttp.py
@@ -31,13 +31,15 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
                 msg_time = msg.time
             elif type(msg) is mirai.Image:
                 arg = ''
-
-                if msg.url:
+                if hasattr(msg, "base64"):
+                    arg = msg.base64
+                    msg_list.append(aiocqhttp.MessageSegment.image(f"base64://{arg}"))
+                elif msg.url:
                     arg = msg.url
+                    msg_list.append(aiocqhttp.MessageSegment.image(arg))
                 elif msg.path:
                     arg = msg.path
-
-                msg_list.append(aiocqhttp.MessageSegment.image(arg))
+                    msg_list.append(aiocqhttp.MessageSegment.image(arg))
             elif type(msg) is mirai.At:
                 msg_list.append(aiocqhttp.MessageSegment.at(msg.target))
             elif type(msg) is mirai.AtAll:

--- a/pkg/platform/sources/aiocqhttp.py
+++ b/pkg/platform/sources/aiocqhttp.py
@@ -31,7 +31,7 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
                 msg_time = msg.time
             elif type(msg) is mirai.Image:
                 arg = ''
-                if hasattr(msg, "base64"):
+                if msg.base64:
                     arg = msg.base64
                     msg_list.append(aiocqhttp.MessageSegment.image(f"base64://{arg}"))
                 elif msg.url:


### PR DESCRIPTION
当qqbot 发送图片时msg是base64 ， 源代码中缺失对于base64的处理。导致无法发送图片。
关联的issues
Fixes #778

