### PR TITLE
fixed pkg\provider\entities.py\get_content_mirai_message_chain中ce.type图片类型不正确的异常

### DIFF
--- a/pkg/provider/entities.py
+++ b/pkg/provider/entities.py
@@ -95,7 +95,7 @@ class Message(pydantic.BaseModel):
             for ce in self.content:
                 if ce.type == 'text':
                     mc.append(mirai.Plain(ce.text))
-                elif ce.type == 'image':
+                elif ce.type == 'image_url':
                     if ce.image_url.url.startswith("http"):
                         mc.append(mirai.Image(url=ce.image_url.url))
                     else:  # base64


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
fixed pkg\provider\entities.py\get_content_mirai_message_chain中ce.type图片类型不正确的异常

### 事务

- [√] 已阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)
- [√] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [√] 已编写完善的配置文件字段说明（若有新增）
- [√] 已编写面向用户的新功能说明（若有必要）
- [√] 已测试新功能或更改

### 兼容性

- [√] 已处理版本兼容性
- [√] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
