### PR TITLE
Fixed aiocqhttp mirai.Voice类型无法正确传递url及base64的异常

### DIFF
--- a/pkg/platform/sources/aiocqhttp.py
+++ b/pkg/platform/sources/aiocqhttp.py
@@ -47,7 +47,16 @@ class AiocqhttpMessageConverter(adapter.MessageConverter):
             elif type(msg) is mirai.Face:
                 msg_list.append(aiocqhttp.MessageSegment.face(msg.face_id))
             elif type(msg) is mirai.Voice:
-                msg_list.append(aiocqhttp.MessageSegment.record(msg.path))
+                arg = ''
+                if msg.base64:
+                    arg = msg.base64
+                    msg_list.append(aiocqhttp.MessageSegment.record(f"base64://{arg}"))
+                elif msg.url:
+                    arg = msg.url
+                    msg_list.append(aiocqhttp.MessageSegment.record(arg))
+                elif msg.path:
+                    arg = msg.path
+                    msg_list.append(aiocqhttp.MessageSegment.record(msg.path))
             elif type(msg) is forward.Forward:
 
                 for node in msg.node_list:


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
Fixed aiocqhttp mirai.Voice类型无法正确传递url及base64的异常

### 事务

- [√] 已阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)
- [√] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [√] 已编写完善的配置文件字段说明（若有新增）
- [√] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [√] 已处理版本兼容性
- [] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
