### PR TITLE
fix: 发送正确的图片格式而不是默认的 `image/jpeg`

### DIFF
--- a/pkg/provider/modelmgr/apis/anthropicmsgs.py
+++ b/pkg/provider/modelmgr/apis/anthropicmsgs.py
@@ -72,12 +72,13 @@ class AnthropicMessages(api.LLMAPIRequester):
 
                 for i, ce in enumerate(m.content):
                     if ce.type == "image_url":
+                        base64_image, image_format = await image.qq_image_url_to_base64(ce.image_url.url)
                         alter_image_ele = {
                             "type": "image",
                             "source": {
                                 "type": "base64",
-                                "media_type": "image/jpeg",
-                                "data": await image.qq_image_url_to_base64(ce.image_url.url)
+                                "media_type": f"image/{image_format}",
+                                "data": base64_image
                             }
                         }
                         msg_dict["content"][i] = alter_image_ele

--- a/pkg/provider/modelmgr/apis/chatcmpl.py
+++ b/pkg/provider/modelmgr/apis/chatcmpl.py
@@ -136,7 +136,5 @@ class OpenAIChatCompletions(api.LLMAPIRequester):
         self,
         original_url: str,
     ) -> str:
-        
-        base64_image = await image.qq_image_url_to_base64(original_url)
-
-        return f"data:image/jpeg;base64,{base64_image}"
+        base64_image, image_format = await image.qq_image_url_to_base64(original_url)
+        return f"data:image/{image_format};base64,{base64_image}"

--- a/pkg/provider/modelmgr/apis/ollamachat.py
+++ b/pkg/provider/modelmgr/apis/ollamachat.py
@@ -101,5 +101,5 @@ class OllamaChatCompletions(api.LLMAPIRequester):
             self,
             original_url: str,
     ) -> str:
-        base64_image: str = await image.qq_image_url_to_base64(original_url)
-        return f"data:image/jpeg;base64,{base64_image}"
+        base64_image, image_format = await image.qq_image_url_to_base64(original_url)
+        return f"data:image/{image_format};base64,{base64_image}"

--- a/pkg/utils/image.py
+++ b/pkg/utils/image.py
@@ -8,14 +8,14 @@ import aiohttp
 
 async def qq_image_url_to_base64(
     image_url: str
-) -> str:
-    """将QQ图片URL转为base64
+) -> typing.Tuple[str, str]:
+    """将QQ图片URL转为base64，并返回图片格式
 
     Args:
         image_url (str): QQ图片URL
 
     Returns:
-        str: base64编码
+        typing.Tuple[str, str]: base64编码和图片格式
     """
     parsed = urlparse(image_url)
     query = parse_qs(parsed.query)
@@ -35,7 +35,12 @@ async def qq_image_url_to_base64(
         ) as resp:
             resp.raise_for_status()  # 检查HTTP错误
             file_bytes = await resp.read()
+            content_type = resp.headers.get('Content-Type')
+            if not content_type or not content_type.startswith('image/'):
+                image_format = 'jpeg'
+            else: 
+                image_format = content_type.split('/')[-1]
 
     base64_str = base64.b64encode(file_bytes).decode()
 
-    return base64_str
+    return base64_str, image_format


### PR DESCRIPTION
## 概述

实现/解决/优化的内容:  从 response header 中获取图片文件格式，而不是写死的 `image/jpeg`。由于一部分接口提供商会对图片格式进行验证，所以不能直接使用 `image/jpeg` 作为所有图片的格式。

## 检查清单

### PR 作者完成

- [x] 阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)了吗？
- [ ] 与项目所有者沟通过了吗？

### 项目所有者完成

- [ ] 相关 issues 链接了吗？
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？
- [ ] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [ ] 文档编写了吗？