### PR TITLE
Fix: Add Role Check to Prevent Validation Error

### DIFF
--- a/pkg/provider/modelmgr/apis/chatcmpl.py
+++ b/pkg/provider/modelmgr/apis/chatcmpl.py
@@ -55,6 +55,10 @@ class OpenAIChatCompletions(api.LLMAPIRequester):
     ) -> llm_entities.Message:
         chatcmpl_message = chat_completion.choices[0].message.dict()
 
+        # 确保 role 字段存在且不为 None
+        if 'role' not in chatcmpl_message or chatcmpl_message['role'] is None:
+            chatcmpl_message['role'] = 'assistant'
+
         message = llm_entities.Message(**chatcmpl_message)
 
         return message


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 

在OpenAI ChatCompletion API 请求器处理中转站返回的message时，因部分中转站返回AI回复message中不含role，导致role=none而报Validation Error，故在_make_msg函数中处理完message后添加对role字段的检查，确保 role 字段存在且不为 None。考虑到中转站应该都用OpenAI ChatCompletion API 请求器，所以暂不检查其他请求器返回的message。

## 检查清单

#886 

## PR 作者完成

- [ √] 阅读仓库[贡献指引](https://github.com/RockChinQ/QChatGPT/blob/master/CONTRIBUTING.md)了吗？
- [ √] 与项目所有者沟通过了吗？

### 项目所有者完成

- [x] 相关 issues 链接了吗？
- [x] 配置项写好了吗？迁移写好了吗？生效了吗？
- [x] 依赖写到 requirements.txt 和 core/bootutils/deps.py 了吗
- [x] 文档编写了吗？