### PR TITLE
fix: get_llm_models: model_service is a module, not an attribute

### DIFF
--- a/pkg/plugin/handler.py
+++ b/pkg/plugin/handler.py
@@ -298,7 +298,7 @@ class RuntimeConnectionHandler(handler.Handler):
         @self.action(PluginToRuntimeAction.GET_LLM_MODELS)
         async def get_llm_models(data: dict[str, Any]) -> handler.ActionResponse:
             """Get llm models"""
-            llm_models = await self.ap.model_service.get_llm_models(include_secret=False)
+            llm_models = await self.ap.llm_model_service.get_llm_models(include_secret=False)
             return handler.ActionResponse.success(
                 data={
                     'llm_models': llm_models,


### PR DESCRIPTION
## 概述 / Overview

修复了插件 LLM API 中的属性引用错误。

**问题描述 / Problem:**
在 `pkg/plugin/handler.py:301` 中，`get_llm_models` action 使用了不存在的 `self.ap.model_service` 属性，导致所有调用 `get_llm_models()` API 的插件都会抛出 `AttributeError: 'Application' object has no attribute 'model_service'` 错误。

**根本原因 / Root Cause:**
- `Application` 类中定义的属性是 `llm_model_service`（见 `pkg/core/app.py:113`）
- 但 `pkg/plugin/handler.py:301` 错误地使用了 `self.ap.model_service`
- 正确的用法可以参考 `pkg/api/http/controller/groups/provider/models.py` 中的 `self.ap.llm_model_service.get_llm_models()`

**修复内容 / Fix:**
将 `pkg/plugin/handler.py:301` 中的：
```python
llm_models = await self.ap.model_service.get_llm_models(include_secret=False)
```
修改为：
```python
llm_models = await self.ap.llm_model_service.get_llm_models(include_secret=False)
```

**影响范围 / Impact:**
此修复使得所有需要调用 LangBot LLM API 的插件能够正常工作，包括：
- `get_llm_models()` - 获取已配置的 LLM 模型列表
- 依赖此 API 的 `invoke_llm()` - 调用 LLM 模型

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [x] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect? *(无需配置项和迁移)*
- [x] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py? *(无新增依赖)*
- [ ] 文档编写了吗？ / Have you written the documentation? *(API 文档无需修改，行为保持一致)*