### PR TITLE
fix: because launcher_id and sender_id This caused the user_id parame…

### DIFF
--- a/pkg/provider/runners/cozeapi.py
+++ b/pkg/provider/runners/cozeapi.py
@@ -125,8 +125,8 @@ class CozeAPIRunner(runner.RequestRunner):
         
         注意：由于cozepy没有提供非流式API，这里使用流式API并在结束后一次性返回完整内容
         """
-        user_id = f'{query.launcher_id}_{query.sender_id}'
-        
+        user_id = f'{query.launcher_type.value}_{query.launcher_id}'
+
         # 预处理用户消息
         additional_messages = await self._preprocess_user_message(query)
         
@@ -206,7 +206,7 @@ class CozeAPIRunner(runner.RequestRunner):
         self, query: pipeline_query.Query
     ) -> typing.AsyncGenerator[provider_message.MessageChunk, None]:
         """调用聊天助手（流式）"""
-        user_id = f'{query.launcher_id}_{query.sender_id}'
+        user_id = f'{query.launcher_type.value}_{query.launcher_id}'
 
         # 预处理用户消息
         additional_messages = await self._preprocess_user_message(query)


### PR DESCRIPTION
because launcher_id and sender_id long This caused the user_id parameter of Coze to be too long.

## 概述 / Overview

> 请在此部分填写你实现/解决/优化的内容:  
> Summary of what you implemented/solved/optimized:
修复了应为飞书的launcher_id和sender_id拼接过长导致传入coze的user_id过长的错误

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [ ] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [ ] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?