### PR TITLE
fix: split Wecom messages exceeding 2048-byte limit

### DIFF
--- a/src/langbot/libs/wecom_api/api.py
+++ b/src/langbot/libs/wecom_api/api.py
@@ -197,7 +197,7 @@ class WecomClient:
             self.access_token = await self.get_access_token(self.secret)
 
         url = self.base_url + '/message/send?access_token=' + self.access_token
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=None) as client:
             params = {
                 'touser': user_id,
                 'msgtype': 'text',


### PR DESCRIPTION
## 概述 / Overview

Fix #1065.

企业微信发送消息有2048字节限制，这个PR将消息拆成多个消息。

这个PR还将httpx的超时选项设为None（即不设置超时），因为测试时发现会触发默认的5秒超时报错。

### 更改前后对比截图 / Screenshots

<img width="1248" height="1130" alt="image" src="https://github.com/user-attachments/assets/bf11a8dc-ee7b-4754-8886-8510a5f9da9a" />
<img width="1206" height="1003" alt="image" src="https://github.com/user-attachments/assets/7b41fc8e-a721-48b4-960b-c48b14a01411" />

先前只能发第一段。

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [ ] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?