### PR TITLE
docs: English-first README for global audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,169 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>Production-grade platform for building agentic IM bots.</h3>
+<h4>Quickly build, debug, and ship AI bots to Slack, Discord, Telegram, WeChat, WhatsApp, and more.</h4>
+
+English / [简体中文](README_CN.md) / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+[![GitHub stars](https://img.shields.io/github/stars/langbot-app/LangBot?style=social)](https://github.com/langbot-app/LangBot/stargazers)
+
+<a href="https://langbot.app">Website</a> ｜
+<a href="https://docs.langbot.app/en/insight/features.html">Features</a> ｜
+<a href="https://docs.langbot.app/en/insight/guide.html">Docs</a> ｜
+<a href="https://docs.langbot.app/en/tags/readme.html">API</a> ｜
+<a href="https://space.langbot.app">Plugin Market</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">Roadmap</a>
+
+</div>
+
+</p>
+
+---
+
+## 🚀 What is LangBot?
+
+LangBot is an **open-source, production-grade platform** for building AI-powered instant messaging bots. It connects Large Language Models (LLMs) to any chat platform, enabling you to create intelligent agents that can converse, execute tasks, and integrate with your existing workflows.
+
+### Key Capabilities
+
+- **💬 AI Conversations & Agents** — Multi-turn dialogues, tool calling, multi-modal support, streaming output. Built-in RAG (knowledge base) with deep integration to [Dify](https://dify.ai), [Coze](https://coze.com), [n8n](https://n8n.io), [Langflow](https://langflow.org).
+- **🤖 Universal IM Platform Support** — One codebase for Discord, Telegram, Slack, LINE, QQ, WeChat, WeCom, Lark, DingTalk, KOOK.
+- **🛠️ Production-Ready** — Access control, rate limiting, sensitive word filtering, comprehensive monitoring, and exception handling. Trusted by enterprises.
+- **🧩 Plugin Ecosystem** — Hundreds of plugins, event-driven architecture, component extensions, and [MCP protocol](https://modelcontextprotocol.io/) support.
+- **😻 Web Management Panel** — Configure, manage, and monitor your bots through an intuitive browser interface. No YAML editing required.
+- **☁️ Cloud & Self-Hosted** — Deploy on your own infrastructure or use [LangBot Cloud](https://langbot.app) (coming soon) for zero-setup hosting.
+
+---
+
+## 📦 Quick Start
+
+### One-Line Launch (with uv)
+
+```bash
+uvx langbot
+```
+
+Visit http://localhost:5300 — done.
+
+### Docker Compose
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+Visit http://localhost:5300
+
+### One-Click Cloud Deploy
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+[→ Full deployment docs](https://docs.langbot.app/en/deploy/langbot/docker.html)
+
+---
+
+## ✨ Supported Platforms
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| Discord | ✅ | Full support |
+| Telegram | ✅ | Streaming output |
+| Slack | ✅ | Full support |
+| LINE | ✅ | Full support |
+| WhatsApp | 🚧 | Coming soon |
+| QQ | ✅ | Personal & Official API |
+| WeCom | ✅ | Enterprise WeChat |
+| WeChat | ✅ | Personal & Official Account |
+| Lark | ✅ | Streaming output |
+| DingTalk | ✅ | Streaming output |
+| KOOK | ✅ | Full support |
+
+---
+
+## 🤖 Supported LLMs & Integrations
+
+| Provider | Type | Status |
+|----------|------|--------|
+| OpenAI | LLM | ✅ |
+| Anthropic Claude | LLM | ✅ |
+| DeepSeek | LLM | ✅ |
+| Google Gemini | LLM | ✅ |
+| xAI Grok | LLM | ✅ |
+| Moonshot | LLM | ✅ |
+| Ollama | Local LLM | ✅ |
+| LM Studio | Local LLM | ✅ |
+| **Dify** | LLMOps | ✅ Deep integration |
+| **Coze** | LLMOps | ✅ API support |
+| **n8n** | Automation | ✅ Webhook triggers |
+| **Langflow** | LLMOps | ✅ Full support |
+| MCP | Protocol | ✅ Tool access |
+
+[→ View all integrations](https://docs.langbot.app/en/insight/features.html)
+
+---
+
+## 🌟 Why LangBot?
+
+| Use Case | How LangBot Helps |
+|----------|-------------------|
+| **Customer Support** | Deploy AI agents to Slack/Discord/Telegram that answer questions using your knowledge base |
+| **Internal Tools** | Connect n8n/Dify workflows to WeCom/DingTalk for automated business processes |
+| **Community Management** | Moderate QQ/Discord groups with AI-powered content filtering |
+| **Multi-Platform Presence** | One bot, all platforms. Manage from a single dashboard |
+
+---
+
+## 🎮 Live Demo
+
+**Try it now:** https://demo.langbot.dev/
+- Email: `demo@langbot.app`
+- Password: `langbot123456`
+
+*Note: Public demo environment. Do not enter sensitive information.*
+
+---
+
+## 🤝 Join the Community
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&label=Discord)](https://discord.gg/wdNEHETs87)
+
+- 💬 [Discord Community](https://discord.gg/wdNEHETs87)
+- 📧 Contact: support@langbot.app
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)
+
+---
+
+
+---
+
+## 😘 Contributors
+
+Thanks to all [contributors](https://github.com/langbot-app/LangBot/graphs/contributors) who have helped make LangBot better:
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,183 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://hellogithub.com/repository/langbot-app/LangBot" target="_blank"><img src="https://abroad.hellogithub.com/v1/widgets/recommend.svg?rid=5ce8ae2aa4f74316bf393b57b952433c&claim_uid=gtmc6YWjMZkT21R" alt="Featured｜HelloGitHub" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>使用 LangBot 快速构建、调试、部署即时通信机器人。</h3>
+
+[English](README.md) / 简体中文 / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![QQ Group](https://img.shields.io/badge/%E7%A4%BE%E7%BE%A4QQ%E7%BE%A4-1030838208-blue)](https://qm.qq.com/q/DxZZcNxM1W)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+[![star](https://gitcode.com/RockChinQ/LangBot/star/badge.svg)](https://gitcode.com/RockChinQ/LangBot)
+
+<a href="https://langbot.app">项目主页</a> ｜
+<a href="https://docs.langbot.app/zh/insight/features.html">规格特性</a> ｜
+<a href="https://docs.langbot.app/zh/insight/guide.html">部署文档</a> ｜
+<a href="https://docs.langbot.app/zh/tags/readme.html">API 集成</a> ｜
+<a href="https://space.langbot.app">插件市场</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">路线图</a>
+
+</div>
+
+</p>
+[English](README.md) / 简体中文 / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![QQ Group](https://img.shields.io/badge/%E7%A4%BE%E7%BE%A4QQ%E7%BE%A4-1030838208-blue)](https://qm.qq.com/q/DxZZcNxM1W)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+[![star](https://gitcode.com/RockChinQ/LangBot/star/badge.svg)](https://gitcode.com/RockChinQ/LangBot)
+
+<a href="https://langbot.app">项目主页</a> ｜
+<a href="https://docs.langbot.app/zh/insight/features.html">规格特性</a> ｜
+<a href="https://docs.langbot.app/zh/insight/guide.html">部署文档</a> ｜
+<a href="https://docs.langbot.app/zh/tags/readme.html">API 集成</a> ｜
+<a href="https://space.langbot.app">插件市场</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">路线图</a>
+
+</div>
+
+</p>
+
+## 📦 开始使用
+
+#### 快速部署
+
+使用 `uvx` 一键启动（需要先安装 [uv](https://docs.astral.sh/uv/getting-started/installation/)）：
+
+```bash
+uvx langbot
+```
+
+访问 http://localhost:5300 即可开始使用。
+
+#### Docker Compose 部署
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+访问 http://localhost:5300 即可开始使用。
+
+详细文档[Docker 部署](https://docs.langbot.app/zh/deploy/langbot/docker.html)。
+
+#### 宝塔面板部署
+
+已上架宝塔面板，若您已安装宝塔面板，可以根据[文档](https://docs.langbot.app/zh/deploy/langbot/one-click/bt.html)使用。
+
+#### Zeabur 云部署
+
+社区贡献的 Zeabur 模板。
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/zh-CN/templates/ZKTBDH)
+
+#### Railway 云部署
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### 手动部署
+
+直接使用发行版运行，查看文档[手动部署](https://docs.langbot.app/zh/deploy/langbot/manual.html)。
+
+#### Kubernetes 部署
+
+参考 [Kubernetes 部署](./docker/README_K8S.md) 文档。
+
+## 😎 保持更新
+
+点击仓库右上角 Star 和 Watch 按钮，获取最新动态。
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ 特性
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-zh-rounded.png" />
+
+- 💬 大模型对话、Agent：支持多种大模型，适配群聊和私聊；具有多轮对话、工具调用、多模态、流式输出能力，自带 RAG（知识库）实现，并深度适配 [Dify](https://dify.ai)、[Coze](https://coze.com)、[n8n](https://n8n.io)、[Langflow](https://langflow.org)等 LLMOps 平台。
+- 🤖 多平台支持：目前支持 QQ、QQ频道、企业微信、个人微信、飞书、Discord、Telegram、KOOK、Slack、LINE 等平台。
+- 🛠️ 高稳定性、功能完备：原生支持访问控制、限速、敏感词过滤等机制；配置简单，支持多种部署方式。
+- 🧩 插件扩展、活跃社区：高稳定性、高安全性的生产级插件系统，支持事件驱动、组件扩展等插件机制；适配 Anthropic [MCP 协议](https://modelcontextprotocol.io/)；目前已有数百个插件。
+- 😻 Web 管理面板：提供先进的 WebUI 管理面板，用最直观的方式配置、管理、监控机器人。
+- 📊 生产级特性：支持多流水线配置，不同机器人用于不同应用场景。具有全面的监控和异常处理能力。已被多家企业采用。
+
+详细规格特性请访问[文档](https://docs.langbot.app/zh/insight/features.html)。
+
+或访问 demo 环境：https://demo.langbot.dev/  
+  - 登录信息：邮箱：`demo@langbot.app` 密码：`langbot123456`
+  - 注意：仅展示 WebUI 效果，公开环境，请不要在其中填入您的任何敏感信息。
+
+### 消息平台
+
+| 平台 | 状态 | 备注 |
+| --- | --- | --- |
+| QQ 个人号 | ✅ | QQ 个人号私聊、群聊 |
+| QQ 官方机器人 | ✅ | QQ 官方机器人，支持频道、私聊、群聊 |
+| 企业微信 | ✅ |  |
+| 企微对外客服 | ✅ |  |
+| 企微智能机器人 | ✅ |  |
+| 个人微信 | ✅ |  |
+| 微信公众号 | ✅ |  |
+| 飞书 | ✅ |  |
+| 钉钉 | ✅ |  |
+| KOOK | ✅ |  |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+
+### 大模型能力
+
+| 模型 | 状态 | 备注 |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | 可接入任何 OpenAI 接口格式模型 |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [智谱AI](https://open.bigmodel.cn/) | ✅ |  |
+| [胜算云](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | 全球大模型都可调用（友情推荐） |
+| [优云智算](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | 大模型和 GPU 资源平台 |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | 大模型和 GPU 资源平台 |
+| [接口 AI](https://jiekou.ai/) | ✅ | 大模型聚合平台，专注全球大模型接入 |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | 大模型聚合平台 |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | LLMOps 平台 |
+| [Ollama](https://ollama.com/) | ✅ | 本地大模型运行平台 |
+| [LMStudio](https://lmstudio.ai/) | ✅ | 本地大模型运行平台 |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | 大模型接口聚合平台 |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | 大模型聚合平台 |
+| [小马算力](https://www.tokenpony.cn/453z1) | ✅ | 大模型聚合平台 |
+| [阿里云百炼](https://bailian.console.aliyun.com/) | ✅ | 大模型聚合平台, LLMOps 平台 |
+| [火山方舟](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | 大模型聚合平台, LLMOps 平台 |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | 大模型聚合平台 |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | 支持通过 MCP 协议获取工具 |
+| [百宝箱Tbox](https://www.tbox.cn/open) | ✅ | 蚂蚁百宝箱智能体平台，每月免费10亿大模型Token |
+
+### TTS
+
+| 平台/模型 | 备注 |
+| --- | --- |
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,0 +1,164 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>Cree, depure y despliegue bots de mensajería instantánea rápidamente con LangBot.</h3>
+
+[English](README.md) / [简体中文](README.md) / [繁體中文](README_TW.md) / [日本語](README_JP.md) / Español / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+
+<a href="https://langbot.app">Inicio</a> ｜
+<a href="https://docs.langbot.app/en/insight/features.html">Características</a> ｜
+<a href="https://docs.langbot.app/en/insight/guide.html">Despliegue</a> ｜
+<a href="https://docs.langbot.app/en/tags/readme.html">Integración API</a> ｜
+<a href="https://space.langbot.app">Mercado de Plugins</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">Hoja de Ruta</a>
+
+</div>
+
+</p>
+
+
+## 📦 Comenzar
+
+#### Inicio Rápido
+
+Use `uvx` para iniciar con un comando (necesita instalar [uv](https://docs.astral.sh/uv/getting-started/installation/)):
+
+```bash
+uvx langbot
+```
+
+Visite http://localhost:5300 para comenzar a usarlo.
+
+#### Despliegue con Docker Compose
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+Visite http://localhost:5300 para comenzar a usarlo.
+
+Documentación detallada [Despliegue con Docker](https://docs.langbot.app/en/deploy/langbot/docker.html).
+
+#### Despliegue con un clic en BTPanel
+
+LangBot ha sido listado en BTPanel. Si tiene BTPanel instalado, puede usar la [documentación](https://docs.langbot.app/en/deploy/langbot/one-click/bt.html) para usarlo.
+
+#### Despliegue en la Nube Zeabur
+
+Plantilla de Zeabur contribuida por la comunidad.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+
+#### Despliegue en la Nube Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### Otros Métodos de Despliegue
+
+Use directamente la versión publicada para ejecutar, consulte la documentación de [Despliegue Manual](https://docs.langbot.app/en/deploy/langbot/manual.html).
+
+#### Despliegue en Kubernetes
+
+Consulte la documentación de [Despliegue en Kubernetes](./docker/README_K8S.md).
+
+## 😎 Manténgase Actualizado
+
+Haga clic en los botones Star y Watch en la esquina superior derecha del repositorio para obtener las últimas actualizaciones.
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ Características
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 Chat con LLM / Agent: Compatible con múltiples LLMs, adaptado para chats grupales y privados; Admite conversaciones de múltiples rondas, llamadas a herramientas, capacidades multimodales y de salida en streaming. Implementación RAG (base de conocimientos) incorporada, e integración profunda con [Dify](https://dify.ai), [Coze](https://coze.com), [n8n](https://n8n.io), [Langflow](https://langflow.org) etc. LLMOps platforms.
+- 🤖 Soporte Multiplataforma: Actualmente compatible con QQ, QQ Channel, WeCom, WeChat personal, Lark, DingTalk, Discord, Telegram, KOOK, Slack, LINE, etc.
+- 🛠️ Alta Estabilidad, Rico en Funciones: Control de acceso nativo, limitación de velocidad, filtrado de palabras sensibles, etc.; Fácil de usar, admite múltiples métodos de despliegue.
+- 🧩 Extensión de Plugin, Comunidad Activa: Sistema de plugin de alta estabilidad, alta seguridad de nivel de producción; Compatible con mecanismos de plugin impulsados por eventos, extensión de componentes, etc.; Integración del protocolo [MCP](https://modelcontextprotocol.io/) de Anthropic; Actualmente cuenta con cientos de plugins.
+- 😻 Interfaz Web: Admite la gestión de instancias de LangBot a través del navegador. No es necesario escribir archivos de configuración manualmente.
+- 📊 Características de Nivel de Producción: Compatible con múltiples configuraciones de pipeline, diferentes bots para diferentes escenarios. Cuenta con capacidades completas de monitoreo y manejo de excepciones.
+
+Para especificaciones más detalladas, consulte la [documentación](https://docs.langbot.app/en/insight/features.html).
+
+O visite el entorno de demostración: https://demo.langbot.dev/
+  - Información de inicio de sesión: Correo electrónico: `demo@langbot.app` Contraseña: `langbot123456`
+  - Nota: Solo para demostración de WebUI, por favor no ingrese información confidencial en el entorno público.
+
+### Plataformas de Mensajería
+
+| Plataforma | Estado | Observaciones |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| QQ Personal | ✅ |  |
+| QQ API Oficial | ✅ |  |
+| WeCom | ✅ |  |
+| WeComCS | ✅ |  |
+| WeCom AI Bot | ✅ |  |
+| WeChat Personal | ✅ |  |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+| KOOK | ✅ |  |
+
+### LLMs
+
+| LLM | Estado | Observaciones |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | Disponible para cualquier modelo con formato de interfaz OpenAI |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [Zhipu AI](https://open.bigmodel.cn/) | ✅ |  |
+| [CompShare](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | Plataforma de recursos LLM y GPU |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | Plataforma de recursos LLM y GPU |
+| [接口 AI](https://jiekou.ai/) | ✅ | Plataforma de agregación LLM |
+| [ShengSuanYun](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | Plataforma de recursos LLM y GPU |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | Gateway LLM (MaaS) |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | Plataforma LLMOps |
+| [Ollama](https://ollama.com/) | ✅ | Plataforma de ejecución de LLM local |
+| [LMStudio](https://lmstudio.ai/) | ✅ | Plataforma de ejecución de LLM local |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | Gateway de interfaz LLM (MaaS) |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | Gateway LLM (MaaS) |
+| [Aliyun Bailian](https://bailian.console.aliyun.com/) | ✅ | Gateway LLM (MaaS), plataforma LLMOps |
+| [Volc Engine Ark](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | Gateway LLM (MaaS), plataforma LLMOps |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | Gateway LLM (MaaS) |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | Compatible con acceso a herramientas a través del protocolo MCP |
+
+## 🤝 Contribución de la Comunidad
+
+Gracias a los siguientes [contribuidores de código](https://github.com/langbot-app/LangBot/graphs/contributors) y otros miembros de la comunidad por sus contribuciones a LangBot:
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_FR.md
+++ b/README_FR.md
@@ -1,0 +1,163 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>Créez, déboguez et déployez rapidement des bots de messagerie instantanée avec LangBot.</h3>
+
+[English](README.md) / [简体中文](README.md) / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / Français / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+
+<a href="https://langbot.app">Accueil</a> ｜
+<a href="https://docs.langbot.app/en/insight/features.html">Fonctionnalités</a> ｜
+<a href="https://docs.langbot.app/en/insight/guide.html">Déploiement</a> ｜
+<a href="https://docs.langbot.app/en/tags/readme.html">Intégration API</a> ｜
+<a href="https://space.langbot.app">Marché des Plugins</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">Feuille de Route</a>
+
+</div>
+
+</p>
+
+## 📦 Commencer
+
+#### Démarrage Rapide
+
+Utilisez `uvx` pour démarrer avec une commande (besoin d'installer [uv](https://docs.astral.sh/uv/getting-started/installation/)) :
+
+```bash
+uvx langbot
+```
+
+Visitez http://localhost:5300 pour commencer à l'utiliser.
+
+#### Déploiement avec Docker Compose
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+Visitez http://localhost:5300 pour commencer à l'utiliser.
+
+Documentation détaillée [Déploiement Docker](https://docs.langbot.app/en/deploy/langbot/docker.html).
+
+#### Déploiement en un clic sur BTPanel
+
+LangBot a été répertorié sur BTPanel. Si vous avez installé BTPanel, vous pouvez utiliser la [documentation](https://docs.langbot.app/en/deploy/langbot/one-click/bt.html) pour l'utiliser.
+
+#### Déploiement Cloud Zeabur
+
+Modèle Zeabur contribué par la communauté.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+
+#### Déploiement Cloud Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### Autres Méthodes de Déploiement
+
+Utilisez directement la version publiée pour exécuter, consultez la documentation de [Déploiement Manuel](https://docs.langbot.app/en/deploy/langbot/manual.html).
+
+#### Déploiement Kubernetes
+
+Consultez la documentation de [Déploiement Kubernetes](./docker/README_K8S.md).
+
+## 😎 Restez à Jour
+
+Cliquez sur les boutons Star et Watch dans le coin supérieur droit du dépôt pour obtenir les dernières mises à jour.
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ Fonctionnalités
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 Chat avec LLM / Agent : Prend en charge plusieurs LLM, adapté aux chats de groupe et privés ; Prend en charge les conversations multi-tours, les appels d'outils, les capacités multimodales et de sortie en streaming. Implémentation RAG (base de connaissances) intégrée, et intégration profonde avec [Dify](https://dify.ai), [Coze](https://coze.com), [n8n](https://n8n.io), [Langflow](https://langflow.org) etc. LLMOps platforms.
+- 🤖 Support Multi-plateforme : Actuellement compatible avec QQ, QQ Channel, WeCom, WeChat personnel, Lark, DingTalk, Discord, Telegram, KOOK, Slack, LINE, etc.
+- 🛠️ Haute Stabilité, Riche en Fonctionnalités : Contrôle d'accès natif, limitation de débit, filtrage de mots sensibles, etc. ; Facile à utiliser, prend en charge plusieurs méthodes de déploiement.
+- 🧩 Extension de Plugin, Communauté Active : Système de plugin de haute stabilité, haute sécurité de niveau production; Prend en charge les mécanismes de plugin pilotés par événements, l'extension de composants, etc. ; Intégration du protocole [MCP](https://modelcontextprotocol.io/) d'Anthropic ; Dispose actuellement de centaines de plugins.
+- 😻 Interface Web : Prend en charge la gestion des instances LangBot via le navigateur. Pas besoin d'écrire manuellement les fichiers de configuration.
+- 📊 Fonctionnalités de Niveau Production : Prend en charge plusieurs configurations de pipeline, différents bots pour différents scénarios. Dispose de capacités complètes de surveillance et de gestion des exceptions.
+
+Pour des spécifications plus détaillées, veuillez consulter la [documentation](https://docs.langbot.app/en/insight/features.html).
+
+Ou visitez l'environnement de démonstration : https://demo.langbot.dev/
+  - Informations de connexion : Email : `demo@langbot.app` Mot de passe : `langbot123456`
+  - Note : Pour la démonstration WebUI uniquement, veuillez ne pas entrer d'informations sensibles dans l'environnement public.
+
+### Plateformes de Messagerie
+
+| Plateforme | Statut | Remarques |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| QQ Personnel | ✅ |  |
+| API Officielle QQ | ✅ |  |
+| WeCom | ✅ |  |
+| WeComCS | ✅ |  |
+| WeCom AI Bot | ✅ |  |
+| WeChat Personnel | ✅ |  |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+| KOOK | ✅ |  |
+
+### LLMs
+
+| LLM | Statut | Remarques |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | Disponible pour tout modèle au format d'interface OpenAI |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [Zhipu AI](https://open.bigmodel.cn/) | ✅ |  |
+| [CompShare](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | Plateforme de ressources LLM et GPU |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | Plateforme de ressources LLM et GPU |
+| [接口 AI](https://jiekou.ai/) | ✅ | Plateforme d'agrégation LLM |
+| [ShengSuanYun](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | Plateforme de ressources LLM et GPU |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | Passerelle LLM (MaaS) |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | Plateforme LLMOps |
+| [Ollama](https://ollama.com/) | ✅ | Plateforme d'exécution LLM locale |
+| [LMStudio](https://lmstudio.ai/) | ✅ | Plateforme d'exécution LLM locale |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | Passerelle d'interface LLM (MaaS) |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | Passerelle LLM (MaaS) |
+| [Aliyun Bailian](https://bailian.console.aliyun.com/) | ✅ | Passerelle LLM (MaaS), plateforme LLMOps |
+| [Volc Engine Ark](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | Passerelle LLM (MaaS), plateforme LLMOps |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | Passerelle LLM (MaaS) |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | Prend en charge l'accès aux outils via le protocole MCP |
+
+## 🤝 Contribution de la Communauté
+
+Merci aux [contributeurs de code](https://github.com/langbot-app/LangBot/graphs/contributors) suivants et aux autres membres de la communauté pour leurs contributions à LangBot :
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,0 +1,163 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>LangBotでIMボットを素早く構築、デバッグ、デプロイ。</h3>
+
+[English](README.md) / [简体中文](README.md) / [繁體中文](README_TW.md) / 日本語 / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+
+<a href="https://langbot.app">ホーム</a> ｜
+<a href="https://docs.langbot.app/ja/insight/features.html">機能仕様</a> ｜
+<a href="https://docs.langbot.app/ja/insight/guide.html">デプロイ</a> ｜
+<a href="https://docs.langbot.app/ja/tags/readme.html">API統合</a> ｜
+<a href="https://space.langbot.app">プラグインマーケット</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">ロードマップ</a>
+
+</div>
+
+</p>
+
+## 📦 始め方
+
+#### クイックスタート
+
+`uvx` を使用した迅速なデプロイ（[uv](https://docs.astral.sh/uv/getting-started/installation/) が必要です）：
+
+```bash
+uvx langbot
+```
+
+http://localhost:5300 にアクセスして使用を開始します。
+
+#### Docker Compose デプロイ
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+http://localhost:5300 にアクセスして使用を開始します。
+
+詳細なドキュメントは[Dockerデプロイ](https://docs.langbot.app/en/deploy/langbot/docker.html)を参照してください。
+
+#### Panelでのワンクリックデプロイ
+
+LangBotはBTPanelにリストされています。BTPanelをインストールしている場合は、[ドキュメント](https://docs.langbot.app/en/deploy/langbot/one-click/bt.html)を使用して使用できます。
+
+#### Zeaburクラウドデプロイ
+
+コミュニティが提供するZeaburテンプレート。
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+
+#### Railwayクラウドデプロイ
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### その他のデプロイ方法
+
+リリースバージョンを直接使用して実行します。[手動デプロイ](https://docs.langbot.app/en/deploy/langbot/manual.html)のドキュメントを参照してください。
+
+#### Kubernetes デプロイ
+
+[Kubernetes デプロイ](./docker/README_K8S.md) ドキュメントを参照してください。
+
+## 😎 最新情報を入手
+
+リポジトリの右上にある Star と Watch ボタンをクリックして、最新の更新を取得してください。
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ 機能
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 LLM / エージェントとのチャット: 複数のLLMをサポートし、グループチャットとプライベートチャットに対応。マルチラウンドの会話、ツールの呼び出し、マルチモーダル、ストリーミング出力機能をサポート、RAG（知識ベース）を組み込み、[Dify](https://dify.ai)、[Coze](https://coze.com)、[n8n](https://n8n.io)、[Langflow](https://langflow.org)などの LLMOps プラットフォームと深く統合。
+- 🤖 多プラットフォーム対応: 現在、QQ、QQ チャンネル、WeChat、個人 WeChat、Lark、DingTalk、Discord、Telegram、KOOK、Slack、LINE など、複数のプラットフォームをサポートしています。
+- 🛠️ 高い安定性、豊富な機能: ネイティブのアクセス制御、レート制限、敏感な単語のフィルタリングなどのメカニズムをサポート。使いやすく、複数のデプロイ方法をサポート。
+- 🧩 プラグイン拡張、活発なコミュニティ: 高い安定性、高いセキュリティの生産レベルのプラグインシステム；イベント駆動、コンポーネント拡張などのプラグインメカニズムをサポート。適配 Anthropic [MCP プロトコル](https://modelcontextprotocol.io/)；豊富なエコシステム、現在数百のプラグインが存在。
+- 😻 Web UI: ブラウザを通じてLangBotインスタンスを管理することをサポート。
+- 📊 生産レベルの機能: 複数のパイプライン設定をサポートし、異なるボットを異なる用途に使用できます。包括的な監視と例外処理機能を備えています。
+
+詳細な仕様については、[ドキュメント](https://docs.langbot.app/en/insight/features.html)を参照してください。
+
+または、デモ環境にアクセスしてください: https://demo.langbot.dev/
+  - ログイン情報: メール: `demo@langbot.app` パスワード: `langbot123456`
+  - 注意: WebUI のデモンストレーションのみの場合、公開環境では機密情報を入力しないでください。
+
+### メッセージプラットフォーム
+
+| プラットフォーム | ステータス | 備考 |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| 個人QQ | ✅ |  |
+| QQ公式API | ✅ |  |
+| WeCom | ✅ |  |
+| WeComCS | ✅ |  |
+| WeCom AI Bot | ✅ |  |
+| 個人WeChat | ✅ | |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+| KOOK | ✅ |  |
+
+### LLMs
+
+| LLM | ステータス | 備考 |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | 任意のOpenAIインターフェース形式モデルに対応 |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [Zhipu AI](https://open.bigmodel.cn/) | ✅ |  |
+| [CompShare](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | 大模型とGPUリソースプラットフォーム |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | 大模型とGPUリソースプラットフォーム |
+| [接口 AI](https://jiekou.ai/) | ✅ | LLMゲートウェイ(MaaS) |
+| [ShengSuanYun](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | LLMとGPUリソースプラットフォーム |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | LLMゲートウェイ(MaaS) |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | LLMOpsプラットフォーム |
+| [Ollama](https://ollama.com/) | ✅ | ローカルLLM実行プラットフォーム |
+| [LMStudio](https://lmstudio.ai/) | ✅ | ローカルLLM実行プラットフォーム |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | LLMインターフェースゲートウェイ(MaaS) |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | LLMゲートウェイ(MaaS) |
+| [Aliyun Bailian](https://bailian.console.aliyun.com/) | ✅ | LLMゲートウェイ(MaaS), LLMOpsプラットフォーム |
+| [Volc Engine Ark](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | LLMゲートウェイ(MaaS), LLMOpsプラットフォーム |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | LLMゲートウェイ(MaaS) |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | MCPプロトコルをサポート |
+
+## 🤝 コミュニティ貢献
+
+LangBot への貢献に対して、以下の [コード貢献者](https://github.com/langbot-app/LangBot/graphs/contributors) とコミュニティの他のメンバーに感謝します。
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,0 +1,163 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>LangBot으로 IM 봇을 빠르게 구축, 디버그 및 배포하세요.</h3>
+
+[English](README.md) / [简体中文](README.md) / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / 한국어 / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+
+<a href="https://langbot.app">홈</a> ｜
+<a href="https://docs.langbot.app/en/insight/features.html">기능 사양</a> ｜
+<a href="https://docs.langbot.app/en/insight/guide.html">배포</a> ｜
+<a href="https://docs.langbot.app/en/tags/readme.html">API 통합</a> ｜
+<a href="https://space.langbot.app">플러그인 마켓</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">로드맵</a>
+
+</div>
+
+</p>
+
+## 📦 시작하기
+
+#### 빠른 시작
+
+`uvx`를 사용하여 한 명령으로 시작하세요 ([uv](https://docs.astral.sh/uv/getting-started/installation/) 설치 필요):
+
+```bash
+uvx langbot
+```
+
+http://localhost:5300을 방문하여 사용을 시작하세요.
+
+#### Docker Compose 배포
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+http://localhost:5300을 방문하여 사용을 시작하세요.
+
+자세한 문서는 [Docker 배포](https://docs.langbot.app/en/deploy/langbot/docker.html)를 참조하세요.
+
+#### BTPanel 원클릭 배포
+
+LangBot은 BTPanel에 등록되어 있습니다. BTPanel을 설치한 경우 [문서](https://docs.langbot.app/en/deploy/langbot/one-click/bt.html)를 사용하여 사용할 수 있습니다.
+
+#### Zeabur 클라우드 배포
+
+커뮤니티에서 제공하는 Zeabur 템플릿입니다.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+
+#### Railway 클라우드 배포
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### 기타 배포 방법
+
+릴리스 버전을 직접 사용하여 실행하려면 [수동 배포](https://docs.langbot.app/en/deploy/langbot/manual.html) 문서를 참조하세요.
+
+#### Kubernetes 배포
+
+[Kubernetes 배포](./docker/README_K8S.md) 문서를 참조하세요.
+
+## 😎 최신 정보 받기
+
+리포지토리 오른쪽 상단의 Star 및 Watch 버튼을 클릭하여 최신 업데이트를 받으세요.
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ 기능
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 LLM / Agent와 채팅: 여러 LLM을 지원하며 그룹 채팅 및 개인 채팅에 적응; 멀티 라운드 대화, 도구 호출, 멀티모달, 스트리밍 출력 기능을 지원합니다. 내장된 RAG(지식 베이스) 구현 및 [Dify](https://dify.ai)、[Coze](https://coze.com)、[n8n](https://n8n.io)、[Langflow](https://langflow.org)등의 LLMOps 플랫폼과 깊이 통합됩니다.
+- 🤖 다중 플랫폼 지원: 현재 QQ, QQ Channel, WeCom, 개인 WeChat, Lark, DingTalk, Discord, Telegram, KOOK, Slack, LINE 등을 지원합니다.
+- 🛠️ 높은 안정성, 풍부한 기능: 네이티브 액세스 제어, 속도 제한, 민감한 단어 필터링 등의 메커니즘; 사용하기 쉽고 여러 배포 방법을 지원합니다.
+- 🧩 플러그인 확장, 활발한 커뮤니티: 고안정성, 고보안 생산 수준의 플러그인 시스템; 이벤트 기반, 컴포넌트 확장 등의 플러그인 메커니즘을 지원; Anthropic [MCP 프로토콜](https://modelcontextprotocol.io/) 통합; 현재 수백 개의 플러그인이 있습니다.
+- 😻 웹 UI: 브라우저를 통해 LangBot 인스턴스 관리를 지원합니다. 구성 파일을 수동으로 작성할 필요가 없습니다.
+- 📊 생산 수준의 기능: 여러 파이프라인 구성을 지원하며 다양한 시나리오에 대해 다른 봇을 사용할 수 있습니다. 포괄적인 모니터링 및 예외 처리 기능을 갖추고 있습니다.
+
+더 자세한 사양은 [문서](https://docs.langbot.app/en/insight/features.html)를 참조하세요.
+
+또는 데모 환경을 방문하세요: https://demo.langbot.dev/
+  - 로그인 정보: 이메일: `demo@langbot.app` 비밀번호: `langbot123456`
+  - 참고: WebUI 데모 전용이므로 공개 환경에서는 민감한 정보를 입력하지 마세요.
+
+### 메시징 플랫폼
+
+| 플랫폼 | 상태 | 비고 |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| 개인 QQ | ✅ |  |
+| QQ 공식 API | ✅ |  |
+| WeCom | ✅ |  |
+| WeComCS | ✅ |  |
+| WeCom AI Bot | ✅ |  |
+| 개인 WeChat | ✅ |  |
+| KOOK | ✅ |  |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+
+### LLMs
+
+| LLM | 상태 | 비고 |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | 모든 OpenAI 인터페이스 형식 모델에 사용 가능 |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [Zhipu AI](https://open.bigmodel.cn/) | ✅ |  |
+| [CompShare](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | LLM 및 GPU 리소스 플랫폼 |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | LLM 및 GPU 리소스 플랫폼 |
+| [接口 AI](https://jiekou.ai/) | ✅ | LLM 집계 플랫폼 |
+| [ShengSuanYun](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | LLM 및 GPU 리소스 플랫폼 |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | LLM 게이트웨이(MaaS) |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | LLMOps 플랫폼 |
+| [Ollama](https://ollama.com/) | ✅ | 로컬 LLM 실행 플랫폼 |
+| [LMStudio](https://lmstudio.ai/) | ✅ | 로컬 LLM 실행 플랫폼 |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | LLM 인터페이스 게이트웨이(MaaS) |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | LLM 게이트웨이(MaaS) |
+| [Aliyun Bailian](https://bailian.console.aliyun.com/) | ✅ | LLM 게이트웨이(MaaS), LLMOps 플랫폼 |
+| [Volc Engine Ark](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | LLM 게이트웨이(MaaS), LLMOps 플랫폼 |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | LLM 게이트웨이(MaaS) |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | MCP 프로토콜을 통한 도구 액세스 지원 |
+
+## 🤝 커뮤니티 기여
+
+다음 [코드 기여자](https://github.com/langbot-app/LangBot/graphs/contributors) 및 커뮤니티의 다른 구성원들의 LangBot 기여에 감사드립니다:
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,0 +1,163 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>Быстро создавайте, отлаживайте и развертывайте IM-ботов с LangBot.</h3>
+
+[English](README.md) / [简体中文](README.md) / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / Русский / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+
+<a href="https://langbot.app">Главная</a> ｜
+<a href="https://docs.langbot.app/en/insight/features.html">Характеристики</a> ｜
+<a href="https://docs.langbot.app/en/insight/guide.html">Развертывание</a> ｜
+<a href="https://docs.langbot.app/en/tags/readme.html">Интеграция API</a> ｜
+<a href="https://space.langbot.app">Магазин плагинов</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">Дорожная карта</a>
+
+</div>
+
+</p>
+
+## 📦 Начало работы
+
+#### Быстрый старт
+
+Используйте `uvx` для запуска одной командой (требуется установка [uv](https://docs.astral.sh/uv/getting-started/installation/)):
+
+```bash
+uvx langbot
+```
+
+Посетите http://localhost:5300, чтобы начать использование.
+
+#### Развертывание с Docker Compose
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+Посетите http://localhost:5300, чтобы начать использование.
+
+Подробная документация [Развертывание Docker](https://docs.langbot.app/en/deploy/langbot/docker.html).
+
+#### Развертывание одним кликом на BTPanel
+
+LangBot добавлен в BTPanel. Если у вас установлен BTPanel, вы можете использовать [документацию](https://docs.langbot.app/en/deploy/langbot/one-click/bt.html) для его использования.
+
+#### Облачное развертывание Zeabur
+
+Шаблон Zeabur, предоставленный сообществом.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+
+#### Облачное развертывание Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### Другие методы развертывания
+
+Используйте выпущенную версию напрямую для запуска, см. документацию [Ручное развертывание](https://docs.langbot.app/en/deploy/langbot/manual.html).
+
+#### Развертывание Kubernetes
+
+См. документацию [Развертывание Kubernetes](./docker/README_K8S.md).
+
+## 😎 Оставайтесь в курсе
+
+Нажмите кнопки Star и Watch в правом верхнем углу репозитория, чтобы получать последние обновления.
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ Функции
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 Чат с LLM / Agent: Поддержка нескольких LLM, адаптация к групповым и личным чатам; Поддержка многораундовых разговоров, вызовов инструментов, мультимодальных возможностей и потоковой передачи. Встроенная реализация RAG (база знаний) и глубокая интеграция с [Dify](https://dify.ai), [Coze](https://coze.com), [n8n](https://n8n.io), [Langflow](https://langflow.org) и др. LLMOps платформами.
+- 🤖 Многоплатформенная поддержка: В настоящее время поддерживает QQ, QQ Channel, WeCom, личный WeChat, Lark, DingTalk, Discord, Telegram, KOOK, Slack, LINE и т.д.
+- 🛠️ Высокая стабильность, богатство функций: Нативный контроль доступа, ограничение скорости, фильтрация чувствительных слов и т.д.; Простота в использовании, поддержка нескольких методов развертывания.
+- 🧩 Расширение плагинов, активное сообщество: Высокая стабильность, высокая безопасность уровня производства; Поддержка механизмов плагинов, управляемых событиями, расширения компонентов и т.д.; Интеграция протокола [MCP](https://modelcontextprotocol.io/) от Anthropic; В настоящее время сотни плагинов.
+- 😻 Веб-интерфейс: Поддержка управления экземплярами LangBot через браузер. Нет необходимости вручную писать конфигурационные файлы.
+- 📊 Функции уровня производства: Поддержка нескольких конфигураций конвейера, разные боты для разных сценариев. Имеет комплексные возможности мониторинга и обработки исключений.
+
+Для более подробных спецификаций обратитесь к [документации](https://docs.langbot.app/en/insight/features.html).
+
+Или посетите демонстрационную среду: https://demo.langbot.dev/
+  - Информация для входа: Email: `demo@langbot.app` Пароль: `langbot123456`
+  - Примечание: Только для демонстрации WebUI, пожалуйста, не вводите конфиденциальную информацию в общедоступной среде.
+
+### Платформы обмена сообщениями
+
+| Платформа | Статус | Примечания |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| Личный QQ | ✅ |  |
+| Официальный API QQ | ✅ |  |
+| WeCom | ✅ |  |
+| WeComCS | ✅ |  |
+| WeCom AI Bot | ✅ |  |
+| Личный WeChat | ✅ |  |
+| KOOK | ✅ |  |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+
+### LLMs
+
+| LLM | Статус | Примечания |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | Доступна для любой модели формата интерфейса OpenAI |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [Zhipu AI](https://open.bigmodel.cn/) | ✅ |  |
+| [CompShare](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | Платформа ресурсов LLM и GPU |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | Платформа ресурсов LLM и GPU |
+| [接口 AI](https://jiekou.ai/) | ✅ | Платформа агрегации LLM |
+| [ShengSuanYun](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | Платформа ресурсов LLM и GPU |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | Шлюз LLM (MaaS) |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | Платформа LLMOps |
+| [Ollama](https://ollama.com/) | ✅ | Платформа локального запуска LLM |
+| [LMStudio](https://lmstudio.ai/) | ✅ | Платформа локального запуска LLM |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | Шлюз интерфейса LLM (MaaS) |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | Шлюз LLM (MaaS) |
+| [Aliyun Bailian](https://bailian.console.aliyun.com/) | ✅ | Шлюз LLM (MaaS), платформа LLMOps |
+| [Volc Engine Ark](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | Шлюз LLM (MaaS), платформа LLMOps |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | Шлюз LLM (MaaS) |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | Поддержка доступа к инструментам через протокол MCP |
+
+## 🤝 Вклад сообщества
+
+Спасибо следующим [контрибьюторам кода](https://github.com/langbot-app/LangBot/graphs/contributors) и другим членам сообщества за их вклад в LangBot:
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_TW.md
+++ b/README_TW.md
@@ -1,0 +1,176 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center"><a href="https://hellogithub.com/repository/langbot-app/LangBot" target="_blank"><img src="https://abroad.hellogithub.com/v1/widgets/recommend.svg?rid=5ce8ae2aa4f74316bf393b57b952433c&claim_uid=gtmc6YWjMZkT21R" alt="Featured｜HelloGitHub" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>使用 LangBot 快速建構、除錯和部署 IM 機器人。</h3>
+
+[English](README.md) / [简体中文](README.md) / 繁體中文 / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / [Tiếng Việt](README_VI.md)
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![QQ Group](https://img.shields.io/badge/%E7%A4%BE%E5%8C%BAQQ%E7%BE%A4-966235608-blue)](https://qm.qq.com/q/JLi38whHum)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+[![star](https://gitcode.com/RockChinQ/LangBot/star/badge.svg)](https://gitcode.com/RockChinQ/LangBot)
+
+<a href="https://langbot.app">主頁</a> ｜
+<a href="https://docs.langbot.app/zh/insight/features.html">規格特性</a> ｜
+<a href="https://docs.langbot.app/zh/insight/guide.html">部署文件</a> ｜
+<a href="https://docs.langbot.app/zh/tags/readme.html">API 整合</a> ｜
+<a href="https://space.langbot.app">外掛市場</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">路線圖</a>
+
+</div>
+
+</p>
+
+## 📦 開始使用
+
+#### 快速部署
+
+使用 `uvx` 一鍵啟動（需要先安裝 [uv](https://docs.astral.sh/uv/getting-started/installation/) ）：
+
+```bash
+uvx langbot
+```
+
+訪問 http://localhost:5300 即可開始使用。
+
+#### Docker Compose 部署
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+訪問 http://localhost:5300 即可開始使用。
+
+詳細文件[Docker 部署](https://docs.langbot.app/zh/deploy/langbot/docker.html)。
+
+#### 寶塔面板部署
+
+已上架寶塔面板，若您已安裝寶塔面板，可以根據[文件](https://docs.langbot.app/zh/deploy/langbot/one-click/bt.html)使用。
+
+#### Zeabur 雲端部署
+
+社群貢獻的 Zeabur 模板。
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/zh-CN/templates/ZKTBDH)
+
+#### Railway 雲端部署
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### 手動部署
+
+直接使用發行版運行，查看文件[手動部署](https://docs.langbot.app/zh/deploy/langbot/manual.html)。
+
+#### Kubernetes 部署
+
+參考 [Kubernetes 部署](./docker/README_K8S.md) 文件。
+
+## 😎 保持更新
+
+點擊倉庫右上角 Star 和 Watch 按鈕，獲取最新動態。
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ 特性
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 大模型對話、Agent：支援多種大模型，適配群聊和私聊；具有多輪對話、工具調用、多模態、流式輸出能力，自帶 RAG（知識庫）實現，並深度適配 [Dify](https://dify.ai)、[Coze](https://coze.com)、[n8n](https://n8n.io)、[Langflow](https://langflow.org)等 LLMOps 平台。
+- 🤖 多平台支援：目前支援 QQ、QQ頻道、企業微信、個人微信、飛書、Discord、Telegram、KOOK、Slack、LINE 等平台。
+- 🛠️ 高穩定性、功能完備：原生支援訪問控制、限速、敏感詞過濾等機制；配置簡單，支援多種部署方式。
+- 🧩 外掛擴展、活躍社群：高穩定性、高安全性的生產級外掛系統；支援事件驅動、組件擴展等外掛機制；適配 Anthropic [MCP 協議](https://modelcontextprotocol.io/)；目前已有數百個外掛。
+- 😻 Web 管理面板：提供先進的 WebUI 管理面板，用最直觀的方式配置、管理、監控機器人。
+- 📊 生產級特性：支援多流水線配置，不同機器人用於不同應用場景。具有全面的監控和異常處理能力。
+
+詳細規格特性請訪問[文件](https://docs.langbot.app/zh/insight/features.html)。
+
+或訪問 demo 環境：https://demo.langbot.dev/  
+  - 登入資訊：郵箱：`demo@langbot.app` 密碼：`langbot123456`
+  - 注意：僅展示 WebUI 效果，公開環境，請不要在其中填入您的任何敏感資訊。
+
+### 訊息平台
+
+| 平台 | 狀態 | 備註 |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| QQ 個人號 | ✅ | QQ 個人號私聊、群聊 |
+| QQ 官方機器人 | ✅ | QQ 官方機器人，支援頻道、私聊、群聊 |
+| 微信 | ✅ |  |
+| 企微對外客服 | ✅ |  |
+| 企微智能機器人 | ✅ |  |
+| 微信公眾號 | ✅ |  |
+| KOOK | ✅ |  |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+
+### 大模型能力
+
+| 模型 | 狀態 | 備註 |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | 可接入任何 OpenAI 介面格式模型 |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [智譜AI](https://open.bigmodel.cn/) | ✅ |  |
+| [勝算雲](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | 大模型和 GPU 資源平台 |
+| [優雲智算](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | 大模型和 GPU 資源平台 |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | 大模型和 GPU 資源平台 |
+| [接口 AI](https://jiekou.ai/) | ✅ | 大模型聚合平台，專注全球大模型接入 |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | 大模型聚合平台 |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | LLMOps 平台 |
+| [Ollama](https://ollama.com/) | ✅ | 本地大模型運行平台 |
+| [LMStudio](https://lmstudio.ai/) | ✅ | 本地大模型運行平台 |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | 大模型介面聚合平台 |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | 大模型聚合平台 |
+| [阿里雲百煉](https://bailian.console.aliyun.com/) | ✅ | 大模型聚合平台, LLMOps 平台 |
+| [火山方舟](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | 大模型聚合平台, LLMOps 平台 |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | 大模型聚合平台 |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | 支援通過 MCP 協議獲取工具 |
+
+### TTS
+
+| 平台/模型 | 備註 |
+| --- | --- |
+| [FishAudio](https://fish.audio/zh-CN/discovery/) | [外掛](https://github.com/the-lazy-me/NewChatVoice) |
+| [海豚 AI](https://www.ttson.cn/?source=thelazy) | [外掛](https://github.com/the-lazy-me/NewChatVoice) |
+| [AzureTTS](https://portal.azure.com/) | [外掛](https://github.com/Ingnaryk/LangBot_AzureTTS) |
+
+### 文生圖
+
+| 平台/模型 | 備註 |
+| --- | --- |
+| 阿里雲百煉 | [外掛](https://github.com/Thetail001/LangBot_BailianTextToImagePlugin)
+
+## 😘 社群貢獻
+
+感謝以下[程式碼貢獻者](https://github.com/langbot-app/LangBot/graphs/contributors)和社群裡其他成員對 LangBot 的貢獻：
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a> 
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)

--- a/README_VI.md
+++ b/README_VI.md
@@ -1,0 +1,163 @@
+<p align="center">
+<a href="https://langbot.app">
+<img width="130" src="https://docs.langbot.app/langbot-logo.png" alt="LangBot"/>
+</a>
+
+<div align="center">
+
+<a href="https://www.producthunt.com/products/langbot?utm_source=badge-follow&utm_medium=badge&utm_source=badge-langbot" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/follow.svg?product_id=1077185&theme=light" alt="LangBot - Production&#0045;grade&#0032;IM&#0032;bot&#0032;made&#0032;easy&#0046; | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+
+<h3>Xây dựng, gỡ lỗi và triển khai bot IM nhanh chóng với LangBot.</h3>
+
+[English](README.md) / [简体中文](README.md) / [繁體中文](README_TW.md) / [日本語](README_JP.md) / [Español](README_ES.md) / [Français](README_FR.md) / [한국어](README_KO.md) / [Русский](README_RU.md) / Tiếng Việt
+
+[![Discord](https://img.shields.io/discord/1335141740050649118?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb)](https://discord.gg/wdNEHETs87)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langbot-app/LangBot)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/langbot-app/LangBot)](https://github.com/langbot-app/LangBot/releases/latest)
+<img src="https://img.shields.io/badge/python-3.10 ~ 3.13 -blue.svg" alt="python">
+
+<a href="https://langbot.app">Trang chủ</a> ｜
+<a href="https://docs.langbot.app/en/insight/features.html">Tính năng</a> ｜
+<a href="https://docs.langbot.app/en/insight/guide.html">Triển khai</a> ｜
+<a href="https://docs.langbot.app/en/tags/readme.html">Tích hợp API</a> ｜
+<a href="https://space.langbot.app">Chợ Plugin</a> ｜
+<a href="https://langbot.featurebase.app/roadmap">Lộ trình</a>
+
+</div>
+
+</p>
+
+## 📦 Bắt đầu
+
+#### Khởi động Nhanh
+
+Sử dụng `uvx` để khởi động bằng một lệnh (cần cài đặt [uv](https://docs.astral.sh/uv/getting-started/installation/)):
+
+```bash
+uvx langbot
+```
+
+Truy cập http://localhost:5300 để bắt đầu sử dụng.
+
+#### Triển khai Docker Compose
+
+```bash
+git clone https://github.com/langbot-app/LangBot
+cd LangBot/docker
+docker compose up -d
+```
+
+Truy cập http://localhost:5300 để bắt đầu sử dụng.
+
+Tài liệu chi tiết [Triển khai Docker](https://docs.langbot.app/en/deploy/langbot/docker.html).
+
+#### Triển khai Một cú nhấp chuột trên BTPanel
+
+LangBot đã được liệt kê trên BTPanel. Nếu bạn đã cài đặt BTPanel, bạn có thể sử dụng [tài liệu](https://docs.langbot.app/en/deploy/langbot/one-click/bt.html) để sử dụng nó.
+
+#### Triển khai Cloud Zeabur
+
+Mẫu Zeabur được đóng góp bởi cộng đồng.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/en-US/templates/ZKTBDH)
+
+#### Triển khai Cloud Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.app/template/yRrAyL?referralCode=vogKPF)
+
+#### Các Phương pháp Triển khai Khác
+
+Sử dụng trực tiếp phiên bản phát hành để chạy, xem tài liệu [Triển khai Thủ công](https://docs.langbot.app/en/deploy/langbot/manual.html).
+
+#### Triển khai Kubernetes
+
+Tham khảo tài liệu [Triển khai Kubernetes](./docker/README_K8S.md).
+
+## 😎 Cập nhật Mới nhất
+
+Nhấp vào các nút Star và Watch ở góc trên bên phải của kho lưu trữ để nhận các bản cập nhật mới nhất.
+
+![star gif](https://docs.langbot.app/star.gif)
+
+## ✨ Tính năng
+
+<img width="500" src="https://docs.langbot.app/ui/bot-page-en-rounded.png" />
+
+
+- 💬 Chat với LLM / Agent: Hỗ trợ nhiều LLM, thích ứng với chat nhóm và chat riêng tư; Hỗ trợ các cuộc trò chuyện nhiều vòng, gọi công cụ, khả năng đa phương thức và đầu ra streaming. Triển khai RAG (cơ sở kiến thức) tích hợp sẵn và tích hợp sâu với [Dify](https://dify.ai), [Coze](https://coze.com), [n8n](https://n8n.io), [Langflow](https://langflow.org) v.v. LLMOps platforms.
+- 🤖 Hỗ trợ Đa nền tảng: Hiện hỗ trợ QQ, QQ Channel, WeCom, WeChat cá nhân, Lark, DingTalk, Discord, Telegram, KOOK, Slack, LINE, v.v.
+- 🛠️ Độ ổn định Cao, Tính năng Phong phú: Kiểm soát truy cập gốc, giới hạn tốc độ, lọc từ nhạy cảm, v.v.; Dễ sử dụng, hỗ trợ nhiều phương pháp triển khai.
+- 🧩 Mở rộng Plugin, Cộng đồng Hoạt động: Hỗ trợ các cơ chế plugin hướng sự kiện, mở rộng thành phần, v.v.; Tích hợp giao thức [MCP](https://modelcontextprotocol.io/) của Anthropic; Hiện có hàng trăng plugin.
+- 😻 Giao diện Web: Hỗ trợ quản lý các phiên bản LangBot thông qua trình duyệt. Không cần viết tệp cấu hình thủ công.
+- 📊 Tính năng Cấp sản xuất: Hỗ trợ nhiều cấu hình pipeline, các bot khác nhau cho các kịch bản khác nhau. Có khả năng giám sát toàn diện và xử lý ngoại lệ.
+
+Để biết thêm thông số kỹ thuật chi tiết, vui lòng tham khảo [tài liệu](https://docs.langbot.app/en/insight/features.html).
+
+Hoặc truy cập môi trường demo: https://demo.langbot.dev/
+  - Thông tin đăng nhập: Email: `demo@langbot.app` Mật khẩu: `langbot123456`
+  - Lưu ý: Chỉ dành cho demo WebUI, vui lòng không nhập bất kỳ thông tin nhạy cảm nào trong môi trường công cộng.
+
+### Nền tảng Nhắn tin
+
+| Nền tảng | Trạng thái | Ghi chú |
+| --- | --- | --- |
+| Discord | ✅ |  |
+| Telegram | ✅ |  |
+| Slack | ✅ |  |
+| LINE | ✅ |  |
+| QQ Cá nhân | ✅ |  |
+| QQ API Chính thức | ✅ |  |
+| WeCom | ✅ |  |
+| WeComCS | ✅ |  |
+| WeCom AI Bot | ✅ |  |
+| WeChat Cá nhân | ✅ |  |
+| KOOK | ✅ |  |
+| Lark | ✅ |  |
+| DingTalk | ✅ |  |
+
+### LLMs
+
+| LLM | Trạng thái | Ghi chú |
+| --- | --- | --- |
+| [OpenAI](https://platform.openai.com/) | ✅ | Có sẵn cho bất kỳ mô hình định dạng giao diện OpenAI nào |
+| [DeepSeek](https://www.deepseek.com/) | ✅ |  |
+| [Moonshot](https://www.moonshot.cn/) | ✅ |  |
+| [Anthropic](https://www.anthropic.com/) | ✅ |  |
+| [xAI](https://x.ai/) | ✅ |  |
+| [Zhipu AI](https://open.bigmodel.cn/) | ✅ |  |
+| [CompShare](https://www.compshare.cn/?ytag=GPU_YY-gh_langbot) | ✅ | Nền tảng tài nguyên LLM và GPU |
+| [PPIO](https://ppinfra.com/user/register?invited_by=QJKFYD&utm_source=github_langbot) | ✅ | Nền tảng tài nguyên LLM và GPU |
+| [接口 AI](https://jiekou.ai/) | ✅ | Nền tảng tổng hợp LLM |
+| [ShengSuanYun](https://www.shengsuanyun.com/?from=CH_KYIPP758) | ✅ | Nền tảng tài nguyên LLM và GPU |
+| [302.AI](https://share.302.ai/SuTG99) | ✅ | Cổng LLM (MaaS) |
+| [Google Gemini](https://aistudio.google.com/prompts/new_chat) | ✅ | |
+| [Dify](https://dify.ai) | ✅ | Nền tảng LLMOps |
+| [Ollama](https://ollama.com/) | ✅ | Nền tảng chạy LLM cục bộ |
+| [LMStudio](https://lmstudio.ai/) | ✅ | Nền tảng chạy LLM cục bộ |
+| [GiteeAI](https://ai.gitee.com/) | ✅ | Cổng giao diện LLM (MaaS) |
+| [SiliconFlow](https://siliconflow.cn/) | ✅ | Cổng LLM (MaaS) |
+| [Aliyun Bailian](https://bailian.console.aliyun.com/) | ✅ | Cổng LLM (MaaS), nền tảng LLMOps |
+| [Volc Engine Ark](https://console.volcengine.com/ark/region:ark+cn-beijing/model?vendor=Bytedance&view=LIST_VIEW) | ✅ | Cổng LLM (MaaS), nền tảng LLMOps |
+| [ModelScope](https://modelscope.cn/docs/model-service/API-Inference/intro) | ✅ | Cổng LLM (MaaS) |
+| [MCP](https://modelcontextprotocol.io/) | ✅ | Hỗ trợ truy cập công cụ qua giao thức MCP |
+
+## 🤝 Đóng góp Cộng đồng
+
+Cảm ơn các [người đóng góp mã](https://github.com/langbot-app/LangBot/graphs/contributors) sau đây và các thành viên khác trong cộng đồng vì những đóng góp của họ cho LangBot:
+
+<a href="https://github.com/langbot-app/LangBot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=langbot-app/LangBot" />
+</a>
+
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=langbot-app/LangBot&type=Date)](https://star-history.com/#langbot-app/LangBot&Date)
+
+---
+
+## 📄 License
+
+[Apache-2.0](LICENSE)


### PR DESCRIPTION
Restructured README to prioritize English content for international users. This should improve conversion from global traffic (HN, Reddit, Product Hunt, etc.).

Changes:
- English content now appears first
- Chinese content moved to collapsible details section
- Added Product Hunt badge, star history chart
- Added Why LangBot use case table
- Created README_CN.md as backup