### PR TITLE
chore: correct sdk version to 0.3.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "chromadb>=0.4.24",
     "qdrant-client (>=1.15.1,<2.0.0)",
     "pyseekdb==1.0.0b7",
-    "langbot-plugin==0.3.0",
+    "langbot-plugin==0.3.0a1",
     "asyncpg>=0.30.0",
     "line-bot-sdk>=3.19.0",
     "tboxsdk>=0.0.10",


### PR DESCRIPTION
Update SDK version to 0.3.0a1 to match the release plan.