### PR TITLE
fix(web): prevent saving empty plugin config on unmodified form

### DIFF
--- a/web/src/app/home/components/dynamic-form/DynamicFormComponent.tsx
+++ b/web/src/app/home/components/dynamic-form/DynamicFormComponent.tsx
@@ -143,8 +143,20 @@ export default function DynamicFormComponent({
 
   // 监听表单值变化
   useEffect(() => {
+    // Emit initial form values immediately so the parent always has a valid snapshot,
+    // even if the user saves without modifying any field.
+    // form.watch(callback) only fires on subsequent changes, not on mount.
+    const formValues = form.getValues();
+    const initialFinalValues = itemConfigList.reduce(
+      (acc, item) => {
+        acc[item.name] = formValues[item.name] ?? item.default;
+        return acc;
+      },
+      {} as Record<string, object>,
+    );
+    onSubmit?.(initialFinalValues);
+
     const subscription = form.watch(() => {
-      // 获取完整的表单值，确保包含所有默认值
       const formValues = form.getValues();
       const finalValues = itemConfigList.reduce(
         (acc, item) => {


### PR DESCRIPTION
## 概述 / Overview

Fix a bug where saving plugin configuration without modifying any field overwrites the existing config with an empty object `{}` in the database.

**Root cause:** `DynamicFormComponent` uses `form.watch(callback)` to notify the parent (`PluginForm`) of current form values. However, react-hook-form's `watch(callback)` only fires on **subsequent changes**, not on initial mount. This means `PluginForm.currentFormValues.current` remains as `{}` (its initial value) if the user opens the config dialog and saves without changing anything — sending an empty object to the backend, which blindly overwrites the database.

**Fix:** Emit the initial form values immediately when the `useEffect` runs (before subscribing to `form.watch`), ensuring the parent always has a valid snapshot of the form state.

### 更改前后对比截图 / Screenshots

修改前 / Before:
- Open plugin config dialog → click Save without changes → config in DB becomes `{}`
- Plugin restarts with empty config, all settings lost

修改后 / After:
- Open plugin config dialog → click Save without changes → config in DB preserved correctly
- Plugin restarts with correct config

## 检查清单 / Checklist

### PR 作者完成 / For PR author

- [x] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [x] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.