### PR TITLE
feat(provider): add Novita LLM provider integration

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/requesters/novita.py
+++ b/src/langbot/pkg/provider/modelmgr/requesters/novita.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import typing
+
+import openai
+
+from . import chatcmpl
+
+
+class NovitaChatCompletions(chatcmpl.OpenAIChatCompletions):
+    """Novita ChatCompletion API 请求器"""
+
+    client: openai.AsyncClient
+
+    default_config: dict[str, typing.Any] = {
+        'base_url': 'https://api.novita.ai/openai',
+        'timeout': 120,
+    }

--- a/src/langbot/pkg/provider/modelmgr/requesters/novita.svg
+++ b/src/langbot/pkg/provider/modelmgr/requesters/novita.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="24" height="24" rx="6" fill="#1E90FF"/>
+  <path d="M7 12L10 17L13 7L16 17L19 12L16 7L13 17L10 7H7Z" fill="white"/>
+</svg>

--- a/src/langbot/pkg/provider/modelmgr/requesters/novita.yaml
+++ b/src/langbot/pkg/provider/modelmgr/requesters/novita.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: LLMAPIRequester
+metadata:
+  name: novita-chat-completions
+  label:
+    en_US: Novita
+    zh_Hans: Novita
+  icon: novita.svg
+spec:
+  config:
+  - name: base_url
+    label:
+      en_US: Base URL
+      zh_Hans: 基础 URL
+    type: string
+    required: true
+    default: https://api.novita.ai/openai
+  - name: timeout
+    label:
+      en_US: Timeout
+      zh_Hans: 超时时间
+    type: integer
+    required: true
+    default: 120
+  support_type:
+  - llm
+  - text-embedding
+  provider_category: manufacturer
+execution:
+  python:
+    path: ./novita.py
+    attr: NovitaChatCompletions


### PR DESCRIPTION
This PR adds support for Novita LLM API provider.

## Changes
- Added NovitaChatCompletions requester class extending OpenAIChatCompletions
- Configured Novita API endpoint: https://api.novita.ai/openai
- Added YAML configuration for automatic provider discovery
- Added SVG icon for UI display
- Fully compatible with OpenAI-compatible endpoints via base_url config

OpenAI-compatible endpoint: https://api.novita.ai/openai