### PR TITLE
fix: allow env overrides to create missing config keys

### DIFF
--- a/src/langbot/pkg/core/stages/load_config.py
+++ b/src/langbot/pkg/core/stages/load_config.py
@@ -74,20 +74,26 @@ def _apply_env_overrides_to_config(cfg: dict) -> dict:
         current = cfg
 
         for i, key in enumerate(keys):
-            if not isinstance(current, dict) or key not in current:
+            if not isinstance(current, dict):
                 break
 
             if i == len(keys) - 1:
-                # At the final key - check if it's a scalar value
-                if isinstance(current[key], (dict, list)):
-                    # Skip dict and list types
-                    pass
+                # At the final key
+                if key in current:
+                    if isinstance(current[key], (dict, list)):
+                        # Skip dict and list types
+                        pass
+                    else:
+                        # Valid scalar value - convert and set it
+                        converted_value = convert_value(env_value, current[key])
+                        current[key] = converted_value
                 else:
-                    # Valid scalar value - convert and set it
-                    converted_value = convert_value(env_value, current[key])
-                    current[key] = converted_value
+                    # Key doesn't exist yet - create it as string
+                    current[key] = env_value
             else:
-                # Navigate deeper
+                # Navigate deeper - create intermediate dict if needed
+                if key not in current:
+                    current[key] = {}
                 current = current[key]
 
     return cfg


### PR DESCRIPTION
## Problem

Environment variable overrides (e.g. `SYSTEM__INSTANCE_ID`) were silently skipped when the target key didn't already exist in `data/config.yaml`. 

This caused issues for SaaS/Cloud deployments where:
1. Pod is deployed with `SYSTEM__INSTANCE_ID=<pod-uuid>` env var
2. LangBot image's config template doesn't include `system.instance_id` field
3. `_apply_env_overrides_to_config()` skips the override (key not in config)
4. LangBot falls back to generating a random UUID in `data/labels/instance_id.json`
5. Telemetry reports wrong instance ID → idle timeout tracking breaks

## Fix

Allow env overrides to **create** missing keys (as strings) and missing intermediate dicts, instead of silently skipping them. Existing behavior for keys that already exist is preserved (type conversion based on original value).

## Testing

```python
# Before fix: instance_id = MISSING
# After fix: instance_id = test-pod-uuid-1234
cfg = {'system': {'edition': 'community'}}
os.environ['SYSTEM__INSTANCE_ID'] = 'test-pod-uuid-1234'
result = _apply_env_overrides_to_config(cfg)
assert result['system']['instance_id'] == 'test-pod-uuid-1234'
```