### PR TITLE
fix: get_llm_models handler returns UUID strings instead of full model dicts

### DIFF
--- a/src/langbot/pkg/plugin/handler.py
+++ b/src/langbot/pkg/plugin/handler.py
@@ -314,11 +314,11 @@ class RuntimeConnectionHandler(handler.Handler):
 
         @self.action(PluginToRuntimeAction.GET_LLM_MODELS)
         async def get_llm_models(data: dict[str, Any]) -> handler.ActionResponse:
-            """Get llm models"""
+            """Get llm models, returns list of UUID strings"""
             llm_models = await self.ap.llm_model_service.get_llm_models(include_secret=False)
             return handler.ActionResponse.success(
                 data={
-                    'llm_models': llm_models,
+                    'llm_models': [m['uuid'] for m in llm_models],
                 },
             )
 


### PR DESCRIPTION
## Problem

The plugin SDK declares `get_llm_models() -> list[str]` (UUID strings), but the host handler returned the full model dict list from `llm_model_service.get_llm_models()`.

This caused `TypeError: unhashable type: 'dict'` when `invoke_llm` passed a dict to `get_model_by_uuid` (which is decorated with `@async_lru` and requires hashable arguments).

## Fix

Extract only the `uuid` field to match the SDK contract.

## Testing

Tested end-to-end with a plugin calling `get_llm_models()` → `invoke_llm()` on a dedicated test instance.