### PR TITLE
fix: prevent path traversal in LocalStorageProvider (CWE-22)

### DIFF
--- a/src/langbot/pkg/storage/providers/localstorage.py
+++ b/src/langbot/pkg/storage/providers/localstorage.py
@@ -12,6 +12,23 @@ from .. import provider
 LOCAL_STORAGE_PATH = os.path.join('data', 'storage')
 
 
+def _safe_resolve(base: str, key: str) -> str:
+    """Resolve *key* under *base* and ensure the result stays inside *base*.
+
+    Raises ``ValueError`` if the resolved path escapes the storage root
+    (e.g. via absolute paths, ``..`` components, or symlinks).
+    """
+    # os.path.realpath resolves symlinks and normalises the path.
+    resolved = os.path.realpath(os.path.join(base, key))
+    canonical_base = os.path.realpath(base)
+    # The resolved path must be *strictly* inside the base directory (or equal
+    # to it only for directory operations).  We append os.sep so that a base of
+    # "/data/storage" does not match "/data/storage_evil".
+    if not (resolved == canonical_base or resolved.startswith(canonical_base + os.sep)):
+        raise ValueError(f'Path traversal detected: key {key!r} resolves outside storage root')
+    return resolved
+
+
 class LocalStorageProvider(provider.StorageProvider):
     def __init__(self, ap: app.Application):
         super().__init__(ap)
@@ -23,40 +40,47 @@ class LocalStorageProvider(provider.StorageProvider):
         key: str,
         value: bytes,
     ):
-        if not os.path.exists(os.path.join(LOCAL_STORAGE_PATH, os.path.dirname(key))):
-            os.makedirs(os.path.join(LOCAL_STORAGE_PATH, os.path.dirname(key)))
-        async with aiofiles.open(os.path.join(LOCAL_STORAGE_PATH, f'{key}'), 'wb') as f:
+        resolved = _safe_resolve(LOCAL_STORAGE_PATH, key)
+        parent = os.path.dirname(resolved)
+        if not os.path.exists(parent):
+            os.makedirs(parent)
+        async with aiofiles.open(resolved, 'wb') as f:
             await f.write(value)
 
     async def load(
         self,
         key: str,
     ) -> bytes:
-        async with aiofiles.open(os.path.join(LOCAL_STORAGE_PATH, f'{key}'), 'rb') as f:
+        resolved = _safe_resolve(LOCAL_STORAGE_PATH, key)
+        async with aiofiles.open(resolved, 'rb') as f:
             return await f.read()
 
     async def exists(
         self,
         key: str,
     ) -> bool:
-        return os.path.exists(os.path.join(LOCAL_STORAGE_PATH, f'{key}'))
+        resolved = _safe_resolve(LOCAL_STORAGE_PATH, key)
+        return os.path.exists(resolved)
 
     async def delete(
         self,
         key: str,
     ):
-        os.remove(os.path.join(LOCAL_STORAGE_PATH, f'{key}'))
+        resolved = _safe_resolve(LOCAL_STORAGE_PATH, key)
+        os.remove(resolved)
 
     async def size(
         self,
         key: str,
     ) -> int:
-        return os.path.getsize(os.path.join(LOCAL_STORAGE_PATH, f'{key}'))
+        resolved = _safe_resolve(LOCAL_STORAGE_PATH, key)
+        return os.path.getsize(resolved)
 
     async def delete_dir_recursive(
         self,
         dir_path: str,
     ):
+        resolved = _safe_resolve(LOCAL_STORAGE_PATH, dir_path)
         # 直接删除整个目录
-        if os.path.exists(os.path.join(LOCAL_STORAGE_PATH, dir_path)):
-            shutil.rmtree(os.path.join(LOCAL_STORAGE_PATH, dir_path))
+        if os.path.exists(resolved):
+            shutil.rmtree(resolved)

--- a/tests/unit_tests/storage/test_localstorage_path_traversal.py
+++ b/tests/unit_tests/storage/test_localstorage_path_traversal.py
@@ -1,0 +1,181 @@
+"""
+PoC test for CWE-22 path traversal in LocalStorageProvider.
+
+The LocalStorageProvider uses os.path.join(LOCAL_STORAGE_PATH, key) without
+validating that the resulting path stays inside LOCAL_STORAGE_PATH.
+
+When `key` is an absolute path (e.g. '/etc/passwd'), os.path.join discards
+all previous components and returns the absolute path directly, allowing
+arbitrary file reads, writes, and deletes.
+
+This test must FAIL before the fix and PASS after.
+"""
+
+import os
+import pytest
+from unittest.mock import Mock, patch
+
+from langbot.pkg.storage.providers.localstorage import LocalStorageProvider
+
+
+@pytest.fixture
+def storage_provider(tmp_path):
+    """Create a LocalStorageProvider with a temporary storage path."""
+    storage_path = str(tmp_path / "storage")
+    with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+        mock_app = Mock()
+        provider = LocalStorageProvider(mock_app)
+        yield provider, storage_path
+
+
+class TestPathTraversalPrevention:
+    """Test that LocalStorageProvider rejects path traversal attempts."""
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_save_rejected(self, storage_provider, tmp_path):
+        """Saving with an absolute path key must be blocked."""
+        provider, storage_path = storage_provider
+        target_file = str(tmp_path / "pwned.txt")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            with pytest.raises((ValueError, PermissionError)):
+                await provider.save(target_file, b"malicious content")
+
+        # The file must NOT exist outside the storage directory
+        assert not os.path.exists(target_file), (
+            f"Path traversal succeeded: file was written outside storage to {target_file}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_load_rejected(self, storage_provider, tmp_path):
+        """Loading with an absolute path key must be blocked."""
+        provider, storage_path = storage_provider
+
+        # Create a file outside the storage directory
+        target_file = str(tmp_path / "secret.txt")
+        with open(target_file, "wb") as f:
+            f.write(b"secret data")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            with pytest.raises((ValueError, PermissionError, FileNotFoundError)):
+                data = await provider.load(target_file)
+                assert data != b"secret data", (
+                    "Path traversal succeeded: read file outside storage"
+                )
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_exists_rejected(self, storage_provider, tmp_path):
+        """Exists check with an absolute path key must be blocked or return False."""
+        provider, storage_path = storage_provider
+
+        target_file = str(tmp_path / "check_me.txt")
+        with open(target_file, "wb") as f:
+            f.write(b"data")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            try:
+                result = await provider.exists(target_file)
+                assert result is False, (
+                    "Path traversal succeeded: exists() returned True for file outside storage"
+                )
+            except (ValueError, PermissionError):
+                pass  # Expected
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_delete_rejected(self, storage_provider, tmp_path):
+        """Deleting with an absolute path key must be blocked."""
+        provider, storage_path = storage_provider
+
+        target_file = str(tmp_path / "do_not_delete.txt")
+        with open(target_file, "wb") as f:
+            f.write(b"important data")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            with pytest.raises((ValueError, PermissionError, FileNotFoundError)):
+                await provider.delete(target_file)
+
+        assert os.path.exists(target_file), (
+            "Path traversal succeeded: file outside storage was deleted"
+        )
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_size_rejected(self, storage_provider, tmp_path):
+        """Size check with an absolute path key must be blocked."""
+        provider, storage_path = storage_provider
+
+        target_file = str(tmp_path / "measure_me.txt")
+        with open(target_file, "wb") as f:
+            f.write(b"some data")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            with pytest.raises((ValueError, PermissionError, FileNotFoundError)):
+                await provider.size(target_file)
+
+    @pytest.mark.asyncio
+    async def test_dot_dot_path_traversal_rejected(self, storage_provider, tmp_path):
+        """Relative path traversal with '..' must be blocked."""
+        provider, storage_path = storage_provider
+
+        target_file = str(tmp_path / "above_storage.txt")
+        with open(target_file, "wb") as f:
+            f.write(b"above storage secret")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            relative_key = os.path.join("..", "above_storage.txt")
+            with pytest.raises((ValueError, PermissionError, FileNotFoundError)):
+                data = await provider.load(relative_key)
+                assert data != b"above storage secret"
+
+    @pytest.mark.asyncio
+    async def test_delete_dir_recursive_traversal_rejected(self, storage_provider, tmp_path):
+        """delete_dir_recursive with traversal path must be blocked."""
+        provider, storage_path = storage_provider
+
+        outside_dir = tmp_path / "outside_dir"
+        outside_dir.mkdir()
+        (outside_dir / "file.txt").write_text("important")
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            with pytest.raises((ValueError, PermissionError)):
+                await provider.delete_dir_recursive(str(outside_dir))
+
+        assert outside_dir.exists(), (
+            "Path traversal succeeded: directory outside storage was deleted"
+        )
+
+    @pytest.mark.asyncio
+    async def test_legitimate_key_works(self, storage_provider):
+        """Normal keys without traversal must still work."""
+        provider, storage_path = storage_provider
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            key = "test_image_abc123.png"
+            content = b"PNG image data"
+
+            await provider.save(key, content)
+            assert await provider.exists(key) is True
+            loaded = await provider.load(key)
+            assert loaded == content
+            size = await provider.size(key)
+            assert size == len(content)
+            await provider.delete(key)
+            assert await provider.exists(key) is False
+
+    @pytest.mark.asyncio
+    async def test_legitimate_subdirectory_key_works(self, storage_provider):
+        """Keys with legitimate subdirectories must still work."""
+        provider, storage_path = storage_provider
+
+        with patch("langbot.pkg.storage.providers.localstorage.LOCAL_STORAGE_PATH", storage_path):
+            key = "bot_log_images/img_001.png"
+            content = b"PNG image data"
+
+            await provider.save(key, content)
+            assert await provider.exists(key) is True
+            loaded = await provider.load(key)
+            assert loaded == content
+            await provider.delete(key)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Vulnerability Summary

**CWE-22 — Path Traversal** | **Severity: Critical** | **CVSS ~9.3 (unauthenticated RCE-adjacent)**

`LocalStorageProvider` in `src/langbot/pkg/storage/providers/localstorage.py` constructs file paths via:

```python
os.path.join(LOCAL_STORAGE_PATH, key)
```

When `key` is an **absolute path** (e.g. `"/etc/passwd"`), `os.path.join()` discards all preceding components and returns the absolute path directly. When `key` contains **`..` sequences**, the path resolves outside the storage root. This enables **arbitrary file read, write, and delete** on the host filesystem.

### Data Flow

```
Attacker ──WebSocket──► _process_image_components()
                           │
                           ▼ component["path"] (no validation)
                    storage_provider.load(key="/etc/passwd")
                           │
                           ▼ os.path.join("data/storage", "/etc/passwd")
                                        → "/etc/passwd"
                           │
                           ▼ aiofiles.open("/etc/passwd", "rb")
                           │
                           ▼ base64-encoded content broadcast back to attacker
                           │
                           ▼ os.remove("/etc/passwd")  ← FILE DELETED
```

The **primary attack vector** is the WebSocket endpoint at `/api/v1/pipelines/<pipeline_uuid>/ws/connect`, which:
- Uses `@self.quart_app.websocket()` directly, **bypassing all auth middleware**
- Accepts `Image` message components with an attacker-controlled `path` field
- Passes `path` directly to `storage_provider.load()` → reads the file
- Then calls `os.remove()` on the same path → **deletes the file**

**No authentication is required.** The server binds `0.0.0.0` with CORS `allow_origin="*"`.

### All Callers of `storage_provider` Methods

| # | Caller | Source of `key` | Attacker-Reachable? |
|---|--------|----------------|-------------------|
| 1 | `websocket_adapter._process_image_components()` | `component["path"]` from unauthenticated WebSocket | **Yes — primary vector** |
| 2 | `files.py` GET `/image/<path:image_key>` | URL path (has partial `..` check, but misses absolute paths) | Partially mitigated |
| 3 | `plugin/handler.py` GET_CONFIG_FILE | `data["file_key"]` from plugin IPC | Requires malicious plugin |
| 4 | `kbmgr.py` | `file.file_name` from DB records | Not directly reachable |
| 5 | `rag/service/runtime.py` | Already has its own `normpath` + `..` validation | Has own mitigation |
| 6 | `delete_dir_recursive` callers | Various | Some reachable |

---

## Fix Description

Added a `_safe_resolve(base, key)` function at the **storage provider layer** that:

1. Joins `base` and `key` with `os.path.join()`
2. Canonicalises via `os.path.realpath()` (resolves symlinks and `..`)
3. Verifies the resolved path starts with `os.path.realpath(base) + os.sep`
4. Raises `ValueError` if the path escapes the storage root

Every method on `LocalStorageProvider` (`save`, `load`, `exists`, `delete`, `size`, `delete_dir_recursive`) now calls `_safe_resolve()` before performing any filesystem operation.

### Rationale

- **Defense-in-depth**: The fix is at the lowest I/O layer, protecting **all 6 callers** simultaneously rather than patching each call site individually.
- **Textbook-correct**: `os.path.realpath()` + prefix check is the standard mitigation for CWE-22 in Python (recommended by OWASP, used by Django/Flask internally).
- **No functional regression**: Legitimate keys like `"image_abc.png"` and `"bot_log_images/img_001.png"` continue to work normally.
- **Minimal footprint**: Only 2 files changed — the provider and a new test file.

### Changes

```
 src/langbot/pkg/storage/providers/localstorage.py       | 42 +++++-
 tests/unit_tests/storage/test_localstorage_path_traversal.py | 181 ++++++
 2 files changed, 214 insertions(+), 9 deletions(-)
```

---

## Test Results

9 new unit tests covering all attack vectors:

| Test | Vector | Result |
|------|--------|--------|
| `test_absolute_path_save_rejected` | Absolute path in `save()` | ✅ Pass |
| `test_absolute_path_load_rejected` | Absolute path in `load()` | ✅ Pass |
| `test_absolute_path_exists_rejected` | Absolute path in `exists()` | ✅ Pass |
| `test_absolute_path_delete_rejected` | Absolute path in `delete()` | ✅ Pass |
| `test_absolute_path_size_rejected` | Absolute path in `size()` | ✅ Pass |
| `test_dot_dot_path_traversal_rejected` | `../` relative traversal in `load()` | ✅ Pass |
| `test_delete_dir_recursive_traversal_rejected` | Absolute path in `delete_dir_recursive()` | ✅ Pass |
| `test_legitimate_key_works` | Normal key (flat file) | ✅ Pass |
| `test_legitimate_subdirectory_key_works` | Normal key (subdirectory) | ✅ Pass |

All tests use `tmp_path` fixtures and mock `LOCAL_STORAGE_PATH`, so they are safe, isolated, and reproducible.

---

## Disprove Analysis

We systematically attempted to disprove this finding:

### Auth Check
The WebSocket endpoint uses `@self.quart_app.websocket()` directly, **bypassing all auth middleware** (does not use `self.route()` which enforces auth). The `GET /api/v1/files/image/<path:image_key>` endpoint is explicitly `auth_type=group.AuthType.NONE`. **No authentication protects the exploitable paths.**

### Network Check
- Server binds on `0.0.0.0` (all interfaces)
- CORS set to `allow_origin="*"`
- No network-level restrictions found in configuration

### Deployment Context
Dockerfile runs `uv run main.py` directly. No reverse proxy, VPN, or service mesh configured. The README describes it as a "production-grade platform" intended to be internet-facing.

### Existing Mitigations Found
1. `files.py` GET endpoint has a partial `..` and `\\` check — but **misses absolute paths**
2. `rag/service/runtime.py` has its own `normpath` validation — only covers that one caller
3. Quart `<path:>` converter normalises URLs — mitigates some HTTP-based attacks only
4. **None of these mitigate the WebSocket attack vector**

### Input Validation
**Zero input validation** exists in `localstorage.py` before this fix. The `websocket_adapter._process_image_components()` also has zero validation on `component["path"]`.

### Prior Reports
No prior security issues found via `gh issue list`. No `SECURITY.md` exists. No recent commits to this file address security.

### Fix Adequacy
The fix adds `_safe_resolve()` at the storage provider layer, meaning it protects all callers simultaneously. This is the correct architectural location — defense-in-depth at the lowest I/O layer. No parallel code path bypasses this fix.

### Verdict
**CONFIRMED_VALID** — High confidence. The vulnerability is unambiguously exploitable through the unauthenticated WebSocket endpoint. The `os.path.join("data/storage", "/etc/passwd")` → `"/etc/passwd"` behavior is trivially reproducible.

---

## Preconditions for Exploitation

1. Network access to the LangBot instance (port 5300 by default)
2. LangBot using `LocalStorageProvider` (default for non-S3 deployments)
3. **No additional preconditions** — no auth required, CORS is `*`, binds `0.0.0.0`

---

> **Note:** The unauthenticated WebSocket endpoint is a separate (broader) security issue worth addressing independently. This PR focuses specifically on the storage-layer path traversal vulnerability.