### PR TITLE
fix(dingtalk): use voice recognition text instead of raw audio binary

### DIFF
--- a/src/langbot/libs/dingtalk_api/api.py
+++ b/src/langbot/libs/dingtalk_api/api.py
@@ -268,7 +268,25 @@ class DingTalkClient:
 
                 message_data['Type'] = 'image'
             elif incoming_message.message_type == 'audio':
-                message_data['Audio'] = await self.get_audio_url(incoming_message.to_dict()['content']['downloadCode'])
+                raw_content = incoming_message.to_dict().get('content', {})
+                # 兼容处理：如果 content 仍为 JSON 字符串则进行解析
+                if isinstance(raw_content, str):
+                    try:
+                        raw_content = json.loads(raw_content)
+                    except (json.JSONDecodeError, TypeError):
+                        raw_content = {}
+
+                if self.logger:
+                    await self.logger.info(f'DingTalk audio raw content: {json.dumps(raw_content, ensure_ascii=False)}')
+
+                # 提取钉钉自带的语音转写文字（Powered by Qwen）
+                recognition = raw_content.get('recognition', '')
+                if recognition:
+                    message_data['Content'] = recognition
+
+                download_code = raw_content.get('downloadCode')
+                if download_code:
+                    message_data['Audio'] = await self.get_audio_url(download_code)
 
                 message_data['Type'] = 'audio'
             elif incoming_message.message_type == 'file':

--- a/src/langbot/pkg/platform/sources/dingtalk.py
+++ b/src/langbot/pkg/platform/sources/dingtalk.py
@@ -71,7 +71,8 @@ class DingTalkMessageConverter(abstract_platform_adapter.AbstractMessageConverte
                     yiri_msg_list.append(platform_message.Image(base64=element['Picture']))
         else:
             # 回退到原有简单逻辑
-            if event.content:
+            # 对于音频消息，content 来自 recognition 转写文字，在下方音频处理块中统一处理
+            if event.content and event.type != 'audio':
                 text_content = event.content.replace('@' + bot_name, '')
                 yiri_msg_list.append(platform_message.Plain(text=text_content))
             if event.picture:
@@ -81,7 +82,11 @@ class DingTalkMessageConverter(abstract_platform_adapter.AbstractMessageConverte
         if event.file:
             yiri_msg_list.append(platform_message.File(url=event.file, name=event.name))
         if event.audio:
-            yiri_msg_list.append(platform_message.Voice(base64=event.audio))
+            # 优先使用钉钉自带的语音转写文字（recognition字段）
+            if event.content and event.type == 'audio':
+                yiri_msg_list.append(platform_message.Plain(text=event.content))
+            else:
+                yiri_msg_list.append(platform_message.Voice(base64=event.audio))
 
         chain = platform_message.MessageChain(yiri_msg_list)
 


### PR DESCRIPTION
## Overview

Fix DingTalk voice messages failing with 400 errors on all LLM models.

When a user sends a voice message, DingTalk's callback JSON already contains a 'recognition' field in 'content' (speech-to-text powered by Qwen). However, the current code only extracts 'downloadCode' to download the raw audio binary and packages it as 'file_base64', which is unsupported by most LLM APIs.

This PR:
- api.py: Extracts the 'recognition' text from DingTalk audio message 'content' and stores it in message_data['Content']
- - dingtalk.py: Prioritizes recognition text as 'Plain' text input to LLM; falls back to Voice(base64=...) only when no recognition is available; also fixes a duplicate text issue for audio messages
### Screenshots

Before:

User sends a voice message, bot replies "Request failed". Console log:
```
[WARNING] : Model qwen-max stream failed: Error code: 400 -
{'error': {'message': "Invalid value: file_base64.
Supported values are: 'text','image_url','video_url' and 'video'."}}
```

After:

The recognition text from DingTalk's built-in speech-to-text is correctly extracted as plain text, and the LLM responds normally:
```
Before: Voice msg -> downloadCode -> Voice(base64) -> file_base64 -> LLM -> X 400 Error
After:  Voice msg -> recognition -> Plain(text) -> text -> LLM -> V Normal response
```

## Checklist

### For PR author

- [x] Have you read the contribution guide?
- [ ]  Have you communicated with the project maintainer?
- [x] I have tested the changes and ensured they work as expected.
### For project maintainer

- [ ] Have you linked the related issues?
- [ ] Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] Have you written the documentation?