### PR TITLE
feat(monitoring): 关联反馈记录与消息ID，新增反馈导出

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "chromadb>=1.0.0,<2.0.0",
     "qdrant-client (>=1.15.1,<2.0.0)",
     "pyseekdb==1.1.0.post3",
-    "langbot-plugin==0.3.7",
+    "langbot-plugin==0.3.8",
     "asyncpg>=0.30.0",
     "line-bot-sdk>=3.19.0",
     "tboxsdk>=0.0.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langbot"
-version = "4.9.5"
+version = "4.9.6"
 description = "Production-grade platform for building agentic IM bots"
 readme = "README.md"
 license-files = ["LICENSE"]

--- a/src/langbot/__init__.py
+++ b/src/langbot/__init__.py
@@ -1,3 +1,3 @@
 """LangBot - Production-grade platform for building agentic IM bots"""
 
-__version__ = '4.9.5'
+__version__ = '4.9.6'

--- a/src/langbot/libs/dingtalk_api/api.py
+++ b/src/langbot/libs/dingtalk_api/api.py
@@ -268,7 +268,25 @@ class DingTalkClient:
 
                 message_data['Type'] = 'image'
             elif incoming_message.message_type == 'audio':
-                message_data['Audio'] = await self.get_audio_url(incoming_message.to_dict()['content']['downloadCode'])
+                raw_content = incoming_message.to_dict().get('content', {})
+                # 兼容处理：如果 content 仍为 JSON 字符串则进行解析
+                if isinstance(raw_content, str):
+                    try:
+                        raw_content = json.loads(raw_content)
+                    except (json.JSONDecodeError, TypeError):
+                        raw_content = {}
+
+                if self.logger:
+                    await self.logger.info(f'DingTalk audio raw content: {json.dumps(raw_content, ensure_ascii=False)}')
+
+                # 提取钉钉自带的语音转写文字（Powered by Qwen）
+                recognition = raw_content.get('recognition', '')
+                if recognition:
+                    message_data['Content'] = recognition
+
+                download_code = raw_content.get('downloadCode')
+                if download_code:
+                    message_data['Audio'] = await self.get_audio_url(download_code)
 
                 message_data['Type'] = 'audio'
             elif incoming_message.message_type == 'file':

--- a/src/langbot/libs/dingtalk_api/api.py
+++ b/src/langbot/libs/dingtalk_api/api.py
@@ -182,6 +182,88 @@ class DingTalkClient:
             for handler in self._message_handlers[msg_type]:
                 await handler(event)
 
+    async def _parse_quoted_message(self, replied_msg: dict) -> dict:
+        """Parse the quoted/replied message and extract its content.
+
+        Args:
+            replied_msg: The repliedMsg object from DingTalk message
+
+        Returns:
+            A dict containing the quoted message info with keys:
+            - message_id: The original message ID
+            - msg_type: The message type (text, file, picture, audio, etc.)
+            - content: The text content (if any)
+            - file_url: The file download URL (if file type)
+            - file_name: The file name (if file type)
+            - picture: The picture base64 (if picture type)
+            - audio: The audio base64 (if audio type)
+        """
+        quote_info = {
+            'message_id': replied_msg.get('msgId', ''),
+            'msg_type': replied_msg.get('msgType', ''),
+            'sender_id': replied_msg.get('senderId', ''),
+        }
+
+        msg_type = replied_msg.get('msgType', '')
+        content = replied_msg.get('content', {})
+
+        # Handle content as string (JSON) or dict
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                content = {}
+
+        if msg_type == 'text':
+            # Text message
+            if isinstance(content, dict):
+                quote_info['content'] = content.get('content', '')
+            else:
+                quote_info['content'] = str(content)
+
+        elif msg_type == 'file':
+            # File message
+            download_code = content.get('downloadCode')
+            file_name = content.get('fileName')
+            if download_code and file_name:
+                try:
+                    quote_info['file_url'] = await self.get_file_url(download_code)
+                    quote_info['file_name'] = file_name
+                except Exception as e:
+                    if self.logger:
+                        await self.logger.error(f'Failed to get quoted file URL: {e}')
+
+        elif msg_type == 'picture':
+            # Picture message
+            download_code = content.get('downloadCode')
+            if download_code:
+                try:
+                    quote_info['picture'] = await self.download_image(download_code)
+                except Exception as e:
+                    if self.logger:
+                        await self.logger.error(f'Failed to download quoted image: {e}')
+
+        elif msg_type == 'audio':
+            # Audio message
+            download_code = content.get('downloadCode')
+            if download_code:
+                try:
+                    quote_info['audio'] = await self.get_audio_url(download_code)
+                except Exception as e:
+                    if self.logger:
+                        await self.logger.error(f'Failed to get quoted audio: {e}')
+
+        elif msg_type == 'richText':
+            # Rich text message - extract text content
+            rich_text = content.get('richText', [])
+            texts = []
+            for item in rich_text:
+                if 'text' in item and item['text'] != '\n':
+                    texts.append(item['text'])
+            quote_info['content'] = '\n'.join(texts)
+
+        return quote_info
+
     async def get_message(self, incoming_message: dingtalk_stream.chatbot.ChatbotMessage):
         try:
             # print(json.dumps(incoming_message.to_dict(), indent=4, ensure_ascii=False))
@@ -192,6 +274,15 @@ class DingTalkClient:
                 message_data['conversation_type'] = 'FriendMessage'
             elif str(incoming_message.conversation_type) == '2':
                 message_data['conversation_type'] = 'GroupMessage'
+
+            # Check for quoted/replied message
+            raw_data = incoming_message.to_dict()
+            text_data = raw_data.get('text', {})
+            if isinstance(text_data, dict) and text_data.get('isReplyMsg'):
+                replied_msg = text_data.get('repliedMsg', {})
+                if replied_msg:
+                    quote_info = await self._parse_quoted_message(replied_msg)
+                    message_data['QuotedMessage'] = quote_info
 
             if incoming_message.message_type == 'richText':
                 data = incoming_message.rich_text_content.to_dict()

--- a/src/langbot/libs/dingtalk_api/dingtalkevent.py
+++ b/src/langbot/libs/dingtalk_api/dingtalkevent.py
@@ -47,6 +47,22 @@ class DingTalkEvent(dict):
     def conversation(self):
         return self.get('conversation_type', '')
 
+    @property
+    def quoted_message(self) -> Optional[Dict[str, Any]]:
+        """Get the quoted/replied message info if this is a reply message.
+
+        Returns:
+            A dict containing:
+            - message_id: The original message ID
+            - msg_type: The message type (text, file, picture, audio, etc.)
+            - content: The text content (if any)
+            - file_url: The file download URL (if file type)
+            - file_name: The file name (if file type)
+            - picture: The picture base64 (if picture type)
+            - audio: The audio base64 (if audio type)
+        """
+        return self.get('QuotedMessage')
+
     def __getattr__(self, key: str) -> Optional[Any]:
         """
         允许通过属性访问数据中的任意字段。

--- a/src/langbot/libs/wecom_ai_bot_api/api.py
+++ b/src/langbot/libs/wecom_ai_bot_api/api.py
@@ -71,6 +71,11 @@ class StreamSession:
 class StreamSessionManager:
     """管理 stream 会话的生命周期，并负责队列的生产消费。"""
 
+    # Sessions with registered feedback_ids use a longer TTL to survive the
+    # full like → cancel → dislike feedback flow. Must align with the adapter's
+    # _stream_to_monitoring_msg TTL (wecombot.py).
+    _FEEDBACK_SESSION_TTL = 600  # 10 minutes
+
     def __init__(self, logger: EventLogger, ttl: int = 60) -> None:
         self.logger = logger
 
@@ -214,11 +219,17 @@ class StreamSessionManager:
             session.last_access = time.time()
 
     def cleanup(self) -> None:
-        """定期清理过期会话，防止队列与映射无上限累积。"""
+        """定期清理过期会话，防止队列与映射无上限累积。
+
+        已注册 feedback_id 的会话使用更长的 TTL，确保用户在点赞/取消/点踩流程中
+        不会因为 session 被提前清除而丢失上下文信息。
+        """
         now = time.time()
         expired: list[str] = []
         for stream_id, session in self._sessions.items():
-            if now - session.last_access > self.ttl:
+            # Sessions with registered feedback_ids use a longer TTL
+            effective_ttl = self._FEEDBACK_SESSION_TTL if session.feedback_id else self.ttl
+            if now - session.last_access > effective_ttl:
                 expired.append(stream_id)
 
         for stream_id in expired:

--- a/src/langbot/pkg/pipeline/pipelinemgr.py
+++ b/src/langbot/pkg/pipeline/pipelinemgr.py
@@ -297,6 +297,9 @@ class RuntimePipeline:
             )
             # Store message_id in query variables for LLM call monitoring
             query.variables['_monitoring_message_id'] = message_id
+            # Notify adapter so it can map platform-specific IDs to monitoring message ID
+            if hasattr(query.adapter, 'on_monitoring_message_created'):
+                await query.adapter.on_monitoring_message_created(query, message_id)
         except Exception as e:
             self.ap.logger.error(f'Failed to record query start: {e}')
 

--- a/src/langbot/pkg/platform/sources/dingtalk.py
+++ b/src/langbot/pkg/platform/sources/dingtalk.py
@@ -88,6 +88,33 @@ class DingTalkMessageConverter(abstract_platform_adapter.AbstractMessageConverte
             else:
                 yiri_msg_list.append(platform_message.Voice(base64=event.audio))
 
+        # Handle quoted/replied message - extract content as top-level components
+        # so that plugins like FileReader can process them the same way as direct messages
+        if event.quoted_message:
+            quote_info = event.quoted_message
+            msg_type = quote_info.get('msg_type', '')
+
+            # Process quoted file - add as top-level File component (same as private chat)
+            if msg_type == 'file' and quote_info.get('file_url'):
+                file_name = quote_info.get('file_name', 'file')
+                yiri_msg_list.append(platform_message.File(url=quote_info['file_url'], name=file_name))
+
+            # Process quoted image - add as top-level Image component
+            elif msg_type == 'picture' and quote_info.get('picture'):
+                yiri_msg_list.append(platform_message.Image(base64=quote_info['picture']))
+
+            # Process quoted audio - add as top-level Voice component
+            elif msg_type == 'audio' and quote_info.get('audio'):
+                yiri_msg_list.append(platform_message.Voice(base64=quote_info['audio']))
+
+            # Process quoted text - add as Plain text with context prefix
+            elif msg_type == 'text' and quote_info.get('content'):
+                yiri_msg_list.append(platform_message.Plain(text=f'[引用消息] {quote_info["content"]}'))
+
+            # Process quoted rich text - add as Plain text with context prefix
+            elif msg_type == 'richText' and quote_info.get('content'):
+                yiri_msg_list.append(platform_message.Plain(text=f'[引用消息] {quote_info["content"]}'))
+
         chain = platform_message.MessageChain(yiri_msg_list)
 
         return chain

--- a/src/langbot/pkg/platform/sources/dingtalk.py
+++ b/src/langbot/pkg/platform/sources/dingtalk.py
@@ -71,7 +71,8 @@ class DingTalkMessageConverter(abstract_platform_adapter.AbstractMessageConverte
                     yiri_msg_list.append(platform_message.Image(base64=element['Picture']))
         else:
             # 回退到原有简单逻辑
-            if event.content:
+            # 对于音频消息，content 来自 recognition 转写文字，在下方音频处理块中统一处理
+            if event.content and event.type != 'audio':
                 text_content = event.content.replace('@' + bot_name, '')
                 yiri_msg_list.append(platform_message.Plain(text=text_content))
             if event.picture:
@@ -81,7 +82,11 @@ class DingTalkMessageConverter(abstract_platform_adapter.AbstractMessageConverte
         if event.file:
             yiri_msg_list.append(platform_message.File(url=event.file, name=event.name))
         if event.audio:
-            yiri_msg_list.append(platform_message.Voice(base64=event.audio))
+            # 优先使用钉钉自带的语音转写文字（recognition字段）
+            if event.content and event.type == 'audio':
+                yiri_msg_list.append(platform_message.Plain(text=event.content))
+            else:
+                yiri_msg_list.append(platform_message.Voice(base64=event.audio))
 
         chain = platform_message.MessageChain(yiri_msg_list)
 

--- a/src/langbot/pkg/platform/sources/lark.py
+++ b/src/langbot/pkg/platform/sources/lark.py
@@ -781,9 +781,9 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
 
     # Monitoring message ID mapping for feedback correlation
     # Temp: user Lark message ID → monitoring_message_id (populated by on_monitoring_message_created, consumed by create_message_card)
-    _pending_monitoring_msg: dict[str, str]
+    pending_monitoring_msg: dict[str, str]
     # Final: reply Lark message ID → (monitoring_message_id, timestamp) (used by feedback callbacks)
-    _reply_to_monitoring_msg: dict[str, tuple[str, float]]
+    reply_to_monitoring_msg: dict[str, tuple[str, float]]
     _MONITORING_MAPPING_TTL = 600  # 10 minutes
 
     seq: int  # 用于在发送卡片消息中识别消息顺序，直接以seq作为标识
@@ -834,8 +834,8 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
 
                 # Resolve monitoring message ID from reply message mapping
                 monitoring_msg_id = None
-                if open_message_id and open_message_id in self._reply_to_monitoring_msg:
-                    monitoring_msg_id = self._reply_to_monitoring_msg[open_message_id][0]
+                if open_message_id and open_message_id in self.reply_to_monitoring_msg:
+                    monitoring_msg_id = self.reply_to_monitoring_msg[open_message_id][0]
 
                 feedback_event = platform_events.FeedbackEvent(
                     feedback_id=getattr(event.header, 'event_id', str(uuid.uuid4())),
@@ -883,8 +883,8 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             logger=logger,
             lark_tenant_key=config.get('lark_tenant_key', ''),
             card_id_dict={},
-            _pending_monitoring_msg={},
-            _reply_to_monitoring_msg={},
+            pending_monitoring_msg={},
+            reply_to_monitoring_msg={},
             seq=1,
             listeners={},
             quart_app=quart_app,
@@ -1030,16 +1030,16 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         try:
             user_msg_id = query.message_event.message_chain.message_id
             if user_msg_id:
-                self._pending_monitoring_msg[user_msg_id] = monitoring_message_id
+                self.pending_monitoring_msg[user_msg_id] = monitoring_message_id
         except Exception as e:
             await self.logger.debug(f'Failed to map message to monitoring message: {e}')
 
     def _cleanup_monitoring_mapping(self):
         """Remove entries older than TTL from the reply-to-monitoring mapping."""
         now = time.time()
-        expired = [k for k, (_, ts) in self._reply_to_monitoring_msg.items() if now - ts > self._MONITORING_MAPPING_TTL]
+        expired = [k for k, (_, ts) in self.reply_to_monitoring_msg.items() if now - ts > self._MONITORING_MAPPING_TTL]
         for k in expired:
-            del self._reply_to_monitoring_msg[k]
+            del self.reply_to_monitoring_msg[k]
 
     async def create_card_id(self, message_id):
         try:
@@ -1285,12 +1285,12 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         try:
             user_msg_id = event.message_chain.message_id
             reply_msg_id = getattr(response.data, 'message_id', None)
-            monitoring_msg_id = self._pending_monitoring_msg.pop(user_msg_id, None)
+            monitoring_msg_id = self.pending_monitoring_msg.pop(user_msg_id, None)
             if reply_msg_id and monitoring_msg_id:
-                self._reply_to_monitoring_msg[reply_msg_id] = (monitoring_msg_id, time.time())
+                self.reply_to_monitoring_msg[reply_msg_id] = (monitoring_msg_id, time.time())
                 self._cleanup_monitoring_mapping()
-        except Exception:
-            pass
+        except Exception as e:
+            asyncio.create_task(self.logger.debug(f'Failed to transfer monitoring mapping in create_message_card: {e}'))
 
         return True
 
@@ -1604,8 +1604,8 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
 
                     # Resolve monitoring message ID from reply message mapping
                     monitoring_msg_id = None
-                    if open_message_id and open_message_id in self._reply_to_monitoring_msg:
-                        monitoring_msg_id = self._reply_to_monitoring_msg[open_message_id][0]
+                    if open_message_id and open_message_id in self.reply_to_monitoring_msg:
+                        monitoring_msg_id = self.reply_to_monitoring_msg[open_message_id][0]
 
                     feedback_event = platform_events.FeedbackEvent(
                         feedback_id=data.get('header', {}).get('event_id', str(uuid.uuid4())),

--- a/src/langbot/pkg/platform/sources/lark.py
+++ b/src/langbot/pkg/platform/sources/lark.py
@@ -779,6 +779,13 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
 
     card_id_dict: dict[str, str]  # 消息id到卡片id的映射，便于创建卡片后的发送消息到指定卡片
 
+    # Monitoring message ID mapping for feedback correlation
+    # Temp: user Lark message ID → monitoring_message_id (populated by on_monitoring_message_created, consumed by create_message_card)
+    _pending_monitoring_msg: dict[str, str]
+    # Final: reply Lark message ID → (monitoring_message_id, timestamp) (used by feedback callbacks)
+    _reply_to_monitoring_msg: dict[str, tuple[str, float]]
+    _MONITORING_MAPPING_TTL = 600  # 10 minutes
+
     seq: int  # 用于在发送卡片消息中识别消息顺序，直接以seq作为标识
     bot_uuid: str = None  # 机器人UUID
     app_ticket: str = None  # 商店应用用到
@@ -825,6 +832,11 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                 else:
                     session_id = None
 
+                # Resolve monitoring message ID from reply message mapping
+                monitoring_msg_id = None
+                if open_message_id and open_message_id in self._reply_to_monitoring_msg:
+                    monitoring_msg_id = self._reply_to_monitoring_msg[open_message_id][0]
+
                 feedback_event = platform_events.FeedbackEvent(
                     feedback_id=getattr(event.header, 'event_id', str(uuid.uuid4())),
                     feedback_type=feedback_type,
@@ -832,6 +844,7 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                     user_id=user_id,
                     session_id=session_id,
                     message_id=open_message_id,
+                    stream_id=monitoring_msg_id,
                     source_platform_object=event,
                 )
 
@@ -870,6 +883,8 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             logger=logger,
             lark_tenant_key=config.get('lark_tenant_key', ''),
             card_id_dict={},
+            _pending_monitoring_msg={},
+            _reply_to_monitoring_msg={},
             seq=1,
             listeners={},
             quart_app=quart_app,
@@ -1009,6 +1024,22 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         if self.config.get('enable-stream-reply', None):
             is_stream = True
         return is_stream
+
+    async def on_monitoring_message_created(self, query, monitoring_message_id: str):
+        """Called by pipeline after monitoring message is created, to map user message ID to monitoring message ID."""
+        try:
+            user_msg_id = query.message_event.message_chain.message_id
+            if user_msg_id:
+                self._pending_monitoring_msg[user_msg_id] = monitoring_message_id
+        except Exception as e:
+            await self.logger.debug(f'Failed to map message to monitoring message: {e}')
+
+    def _cleanup_monitoring_mapping(self):
+        """Remove entries older than TTL from the reply-to-monitoring mapping."""
+        now = time.time()
+        expired = [k for k, (_, ts) in self._reply_to_monitoring_msg.items() if now - ts > self._MONITORING_MAPPING_TTL]
+        for k in expired:
+            del self._reply_to_monitoring_msg[k]
 
     async def create_card_id(self, message_id):
         try:
@@ -1249,6 +1280,18 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             raise Exception(
                 f'client.im.v1.message.reply failed, code: {response.code}, msg: {response.msg}, log_id: {response.get_log_id()}, resp: \n{json.dumps(json.loads(response.raw.content), indent=4, ensure_ascii=False)}'
             )
+
+        # Transfer monitoring message mapping: user msg ID → reply msg ID
+        try:
+            user_msg_id = event.message_chain.message_id
+            reply_msg_id = getattr(response.data, 'message_id', None)
+            monitoring_msg_id = self._pending_monitoring_msg.pop(user_msg_id, None)
+            if reply_msg_id and monitoring_msg_id:
+                self._reply_to_monitoring_msg[reply_msg_id] = (monitoring_msg_id, time.time())
+                self._cleanup_monitoring_mapping()
+        except Exception:
+            pass
+
         return True
 
     async def reply_message(
@@ -1559,6 +1602,11 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                     else:
                         session_id = None
 
+                    # Resolve monitoring message ID from reply message mapping
+                    monitoring_msg_id = None
+                    if open_message_id and open_message_id in self._reply_to_monitoring_msg:
+                        monitoring_msg_id = self._reply_to_monitoring_msg[open_message_id][0]
+
                     feedback_event = platform_events.FeedbackEvent(
                         feedback_id=data.get('header', {}).get('event_id', str(uuid.uuid4())),
                         feedback_type=feedback_type,
@@ -1566,6 +1614,7 @@ class LarkAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                         user_id=user_id,
                         session_id=session_id,
                         message_id=open_message_id,
+                        stream_id=monitoring_msg_id,
                         source_platform_object=data,
                     )
 

--- a/src/langbot/pkg/platform/sources/lark.py
+++ b/src/langbot/pkg/platform/sources/lark.py
@@ -709,21 +709,29 @@ class LarkEventConverter(abstract_platform_adapter.AbstractEventConverter):
         message_chain = await LarkMessageConverter.target2yiri(event.event.message, api_client)
 
         # Check for quote/reply message
+        # Extract files/images/voice from quote and add them as top-level components
+        # so that plugins like FileReader can process them the same way as direct messages
         quote_message_id = LarkEventConverter._extract_quote_message_id(event.event.message)
         if quote_message_id:
             quote_chain = await LarkEventConverter._fetch_quoted_message(quote_message_id, api_client)
             if quote_chain:
                 # Filter out Source component from quoted chain, keep only content
-                quote_origin = platform_message.MessageChain(
-                    [comp for comp in quote_chain if not isinstance(comp, platform_message.Source)]
-                )
-                if quote_origin:
-                    message_chain.append(
-                        platform_message.Quote(
-                            message_id=quote_message_id,
-                            origin=quote_origin,
-                        )
-                    )
+                quote_components = [comp for comp in quote_chain if not isinstance(comp, platform_message.Source)]
+
+                # Add quoted content as top-level components instead of wrapping in Quote
+                for comp in quote_components:
+                    if isinstance(comp, platform_message.File):
+                        # Add file as top-level component (same as direct message)
+                        message_chain.append(comp)
+                    elif isinstance(comp, platform_message.Image):
+                        # Add image as top-level component
+                        message_chain.append(comp)
+                    elif isinstance(comp, platform_message.Voice):
+                        # Add voice as top-level component
+                        message_chain.append(comp)
+                    elif isinstance(comp, platform_message.Plain):
+                        # Add text with context prefix
+                        message_chain.append(platform_message.Plain(text=f'[引用消息] {comp.text}'))
 
         if event.event.message.chat_type == 'p2p':
             return platform_events.FriendMessage(

--- a/src/langbot/pkg/platform/sources/wecombot.py
+++ b/src/langbot/pkg/platform/sources/wecombot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import typing
 import asyncio
+import time
 import traceback
 
 import datetime
@@ -293,6 +294,9 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
     _ws_mode: bool = False
     bot_name: str = ''
     listeners: dict = {}
+    # Mapping from wecom stream_id to LangBot monitoring message ID, with TTL
+    _stream_to_monitoring_msg: dict[str, tuple[str, float]] = {}
+    _STREAM_MAPPING_TTL = 600  # 10 minutes
 
     def __init__(self, config: dict, logger: EventLogger):
         enable_webhook = config.get('enable-webhook', False)
@@ -422,6 +426,23 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
         """设置 bot UUID（用于生成 webhook URL）"""
         self.bot_uuid = bot_uuid
 
+    async def on_monitoring_message_created(self, query, monitoring_message_id: str):
+        """Called by pipeline after monitoring message is created, to map stream_id to monitoring message ID."""
+        try:
+            stream_id = query.message_event.source_platform_object.stream_id
+            if stream_id:
+                self._stream_to_monitoring_msg[stream_id] = (monitoring_message_id, time.time())
+                self._cleanup_stream_mapping()
+        except Exception:
+            pass
+
+    def _cleanup_stream_mapping(self):
+        """Remove entries older than TTL from the stream_id to monitoring message mapping."""
+        now = time.time()
+        expired = [k for k, (_, ts) in self._stream_to_monitoring_msg.items() if now - ts > self._STREAM_MAPPING_TTL]
+        for k in expired:
+            del self._stream_to_monitoring_msg[k]
+
     async def _on_feedback(self, **kwargs):
         """Handle feedback event from WeChat Work AI Bot SDK and dispatch as FeedbackEvent."""
         try:
@@ -446,6 +467,10 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                 user_id = session.user_id
                 message_id = session.msg_id
                 stream_id = session.stream_id
+
+            # Replace stream_id with LangBot monitoring message ID if available
+            if stream_id and stream_id in self._stream_to_monitoring_msg:
+                stream_id = self._stream_to_monitoring_msg[stream_id][0]
 
             await self.logger.info(
                 f'Feedback event: feedback_id={feedback_id}, type={feedback_type}, '

--- a/src/langbot/pkg/platform/sources/wecombot.py
+++ b/src/langbot/pkg/platform/sources/wecombot.py
@@ -294,8 +294,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
     _ws_mode: bool = False
     bot_name: str = ''
     listeners: dict = {}
-    # Mapping from wecom stream_id to LangBot monitoring message ID, with TTL
-    _stream_to_monitoring_msg: dict[str, tuple[str, float]] = {}
+    _stream_to_monitoring_msg: dict = {}  # Maps stream_id to (monitoring_message_id, timestamp)
     _STREAM_MAPPING_TTL = 600  # 10 minutes
 
     def __init__(self, config: dict, logger: EventLogger):
@@ -333,8 +332,9 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             bot_account_id=bot_account_id,
             bot_name=bot_name,
             event_converter=event_converter,
+            listeners={},
+            _stream_to_monitoring_msg={},
         )
-        self.listeners = {}
 
     async def reply_message(
         self,
@@ -433,8 +433,8 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
             if stream_id:
                 self._stream_to_monitoring_msg[stream_id] = (monitoring_message_id, time.time())
                 self._cleanup_stream_mapping()
-        except Exception:
-            pass
+        except Exception as e:
+            await self.logger.debug(f'Failed to map stream_id to monitoring message: {e}')
 
     def _cleanup_stream_mapping(self):
         """Remove entries older than TTL from the stream_id to monitoring message mapping."""
@@ -468,9 +468,10 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                 message_id = session.msg_id
                 stream_id = session.stream_id
 
-            # Replace stream_id with LangBot monitoring message ID if available
+            # Resolve stream_id to LangBot monitoring message ID if available
+            monitoring_msg_id = None
             if stream_id and stream_id in self._stream_to_monitoring_msg:
-                stream_id = self._stream_to_monitoring_msg[stream_id][0]
+                monitoring_msg_id = self._stream_to_monitoring_msg[stream_id][0]
 
             await self.logger.info(
                 f'Feedback event: feedback_id={feedback_id}, type={feedback_type}, '
@@ -485,7 +486,7 @@ class WecomBotAdapter(abstract_platform_adapter.AbstractMessagePlatformAdapter):
                 user_id=user_id,
                 session_id=session_id,
                 message_id=message_id,
-                stream_id=stream_id,
+                stream_id=monitoring_msg_id or stream_id,
                 source_platform_object=session,
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1953,7 +1953,7 @@ requires-dist = [
     { name = "ebooklib", specifier = ">=0.18" },
     { name = "gewechat-client", specifier = ">=0.1.5" },
     { name = "html2text", specifier = ">=2024.2.26" },
-    { name = "langbot-plugin", specifier = "==0.3.7" },
+    { name = "langbot-plugin", specifier = "==0.3.8" },
     { name = "langchain", specifier = ">=0.2.0" },
     { name = "langchain-text-splitters", specifier = ">=0.0.1" },
     { name = "lark-oapi", specifier = ">=1.4.15" },
@@ -2009,7 +2009,7 @@ dev = [
 
 [[package]]
 name = "langbot-plugin"
-version = "0.3.7"
+version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2027,9 +2027,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/31/8dc7106cb65004a01e363308343c5a95e35f1722f26c87853e6e12c6fee1/langbot_plugin-0.3.7.tar.gz", hash = "sha256:bc0dea6b1c515d9fc8c3ab14af74bdf3e006d7e20c097b6cb5034f5af4a73cc9", size = 179764, upload-time = "2026-04-03T09:43:17.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/d8/7c8ac9516e35d69ead3e934b408e48541f5772eb88fbed19cd216af4b6c2/langbot_plugin-0.3.8.tar.gz", hash = "sha256:e8e420c3b2f167c9635e3e0af46fb452895be9d68ec05bf112ac5f221c3316f3", size = 179803, upload-time = "2026-04-10T11:05:42.791Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/51/1982c199bd4efbfa3c327c95cca7e4ab502610251567000b348c72bca1b1/langbot_plugin-0.3.7-py3-none-any.whl", hash = "sha256:2e2b9e99163ceb14da28b8ce7c4cbc6990dea15684ec78976bc015e5378feea2", size = 157324, upload-time = "2026-04-03T09:43:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/81/63/4a61b67d4886522647e0b60063da155279b943a6b2e6cd004e29aedf67d1/langbot_plugin-0.3.8-py3-none-any.whl", hash = "sha256:2246f343b4735cb4004cf44462ffb47531222c21efeef163a4acd758ebbec2cd", size = 157354, upload-time = "2026-04-10T11:05:41.525Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1846,7 +1846,7 @@ wheels = [
 
 [[package]]
 name = "langbot"
-version = "4.9.5"
+version = "4.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiocqhttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1840,6 +1854,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aioshutil" },
     { name = "aiosqlite" },
+    { name = "alembic" },
     { name = "anthropic" },
     { name = "argon2-cffi" },
     { name = "async-lru" },
@@ -1919,6 +1934,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.18" },
     { name = "aioshutil", specifier = ">=1.5" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
+    { name = "alembic", specifier = ">=1.15.0" },
     { name = "anthropic", specifier = ">=0.51.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "async-lru", specifier = ">=2.0.5" },
@@ -2407,6 +2423,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119, upload-time = "2025-09-22T04:04:51.801Z" },
     { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314, upload-time = "2025-09-22T04:04:55.024Z" },
     { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768, upload-time = "2025-09-22T04:04:57.097Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]

--- a/web/src/app/home/bots/components/bot-session/BotSessionMonitor.tsx
+++ b/web/src/app/home/bots/components/bot-session/BotSessionMonitor.tsx
@@ -10,7 +10,15 @@ import { useTranslation } from 'react-i18next';
 import { httpClient } from '@/app/infra/http/HttpClient';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
-import { Ban, Bot, Copy, Check, Workflow } from 'lucide-react';
+import {
+  Ban,
+  Bot,
+  Copy,
+  Check,
+  Workflow,
+  ThumbsUp,
+  ThumbsDown,
+} from 'lucide-react';
 import {
   MessageChainComponent,
   Plain,
@@ -54,6 +62,12 @@ interface SessionMessage {
   role?: string | null;
 }
 
+interface SessionFeedback {
+  feedback_type: number; // 1=like, 2=dislike
+  feedback_content?: string | null;
+  stream_id?: string | null;
+}
+
 export interface BotSessionMonitorHandle {
   refreshSessions: () => Promise<void>;
 }
@@ -75,6 +89,9 @@ const BotSessionMonitor = forwardRef<
   const [loadingSessions, setLoadingSessions] = useState(false);
   const [loadingMessages, setLoadingMessages] = useState(false);
   const [copiedUserId, setCopiedUserId] = useState(false);
+  const [feedbackMap, setFeedbackMap] = useState<
+    Record<string, SessionFeedback>
+  >({});
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   const parseSessionType = (sessionId: string): string | null => {
@@ -117,21 +134,50 @@ const BotSessionMonitor = forwardRef<
     [loadSessions],
   );
 
-  const loadMessages = useCallback(async (sessionId: string) => {
-    setLoadingMessages(true);
-    try {
-      const response = await httpClient.getSessionMessages(sessionId);
-      const sorted = (response.messages ?? []).sort(
-        (a, b) =>
-          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-      );
-      setMessages(sorted);
-    } catch (error) {
-      console.error('Failed to load session messages:', error);
-    } finally {
-      setLoadingMessages(false);
-    }
-  }, []);
+  const loadMessages = useCallback(
+    async (sessionId: string) => {
+      setLoadingMessages(true);
+      try {
+        const messagesRes = await httpClient.getSessionMessages(sessionId);
+        const sorted = (messagesRes.messages ?? []).sort(
+          (a, b) =>
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+        );
+        setMessages(sorted);
+
+        // Collect user message IDs for feedback matching
+        const userMsgIds = new Set(
+          sorted.filter((m) => !m.role || m.role === 'user').map((m) => m.id),
+        );
+
+        if (userMsgIds.size > 0) {
+          // Fetch feedback for this bot, then match by stream_id locally
+          const feedbackRes = await httpClient.get<{
+            feedback: SessionFeedback[];
+          }>(
+            `/api/v1/monitoring/feedback?botId=${encodeURIComponent(botId)}&limit=200`,
+          );
+
+          const map: Record<string, SessionFeedback> = {};
+          if (feedbackRes?.feedback) {
+            for (const fb of feedbackRes.feedback) {
+              if (fb.stream_id && userMsgIds.has(fb.stream_id)) {
+                map[fb.stream_id] = fb;
+              }
+            }
+          }
+          setFeedbackMap(map);
+        } else {
+          setFeedbackMap({});
+        }
+      } catch (error) {
+        console.error('Failed to load session messages:', error);
+      } finally {
+        setLoadingMessages(false);
+      }
+    },
+    [botId],
+  );
 
   useEffect(() => {
     loadSessions();
@@ -479,11 +525,21 @@ const BotSessionMonitor = forwardRef<
                     {t('bots.sessionMonitor.noMessages')}
                   </div>
                 ) : (
-                  messages.map((msg) => {
+                  messages.map((msg, msgIndex) => {
                     const isUser = isUserMessage(msg);
                     const isDiscarded =
                       msg.status === 'discarded' ||
                       msg.pipeline_id === PIPELINE_DISCARD;
+                    // For bot replies, find feedback linked to the preceding user message
+                    let msgFeedback: SessionFeedback | undefined;
+                    if (!isUser) {
+                      for (let i = msgIndex - 1; i >= 0; i--) {
+                        if (isUserMessage(messages[i])) {
+                          msgFeedback = feedbackMap[messages[i].id];
+                          break;
+                        }
+                      }
+                    }
                     return (
                       <div
                         key={msg.id}
@@ -543,6 +599,25 @@ const BotSessionMonitor = forwardRef<
                                 {msg.runner_name}
                               </span>
                             )}
+                            {/* Feedback indicator — same line, pushed right */}
+                            {!isUser &&
+                              msgFeedback &&
+                              (msgFeedback.feedback_type === 1 ? (
+                                <span className="inline-flex items-center gap-1 ml-auto text-green-600 dark:text-green-400">
+                                  <ThumbsUp className="w-3 h-3 flex-shrink-0" />
+                                  {t('monitoring.feedback.like')}
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center gap-1 ml-auto text-red-500 dark:text-red-400 truncate max-w-[50%]">
+                                  <ThumbsDown className="w-3 h-3 flex-shrink-0" />
+                                  {t('monitoring.feedback.dislike')}
+                                  {msgFeedback.feedback_content && (
+                                    <span className="text-muted-foreground truncate">
+                                      — {msgFeedback.feedback_content}
+                                    </span>
+                                  )}
+                                </span>
+                              ))}
                           </div>
                         </div>
                       </div>

--- a/web/src/app/home/bots/components/bot-session/BotSessionMonitor.tsx
+++ b/web/src/app/home/bots/components/bot-session/BotSessionMonitor.tsx
@@ -603,17 +603,22 @@ const BotSessionMonitor = forwardRef<
                             {!isUser &&
                               msgFeedback &&
                               (msgFeedback.feedback_type === 1 ? (
-                                <span className="inline-flex items-center gap-1 ml-auto text-green-600 dark:text-green-400">
+                                <span className="inline-flex items-center gap-1 ml-auto text-green-600 dark:text-green-400 cursor-default relative group">
                                   <ThumbsUp className="w-3 h-3 flex-shrink-0" />
                                   {t('monitoring.feedback.like')}
+                                  {msgFeedback.feedback_content && (
+                                    <span className="hidden group-hover:block absolute bottom-full right-0 mb-1 px-3 py-1.5 rounded-lg bg-popover border text-popover-foreground text-xs whitespace-nowrap shadow-md z-10">
+                                      {msgFeedback.feedback_content}
+                                    </span>
+                                  )}
                                 </span>
                               ) : (
-                                <span className="inline-flex items-center gap-1 ml-auto text-red-500 dark:text-red-400 truncate max-w-[50%]">
+                                <span className="inline-flex items-center gap-1 ml-auto text-red-500 dark:text-red-400 cursor-default relative group">
                                   <ThumbsDown className="w-3 h-3 flex-shrink-0" />
                                   {t('monitoring.feedback.dislike')}
                                   {msgFeedback.feedback_content && (
-                                    <span className="text-muted-foreground truncate">
-                                      — {msgFeedback.feedback_content}
+                                    <span className="hidden group-hover:block absolute bottom-full right-0 mb-1 px-3 py-1.5 rounded-lg bg-popover border text-popover-foreground text-xs whitespace-nowrap shadow-md z-10">
+                                      {msgFeedback.feedback_content}
                                     </span>
                                   )}
                                 </span>

--- a/web/src/app/home/monitoring/components/ExportDropdown.tsx
+++ b/web/src/app/home/monitoring/components/ExportDropdown.tsx
@@ -7,6 +7,7 @@ import {
   AlertCircle,
   Users,
   Layers,
+  ThumbsUp,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -25,7 +26,8 @@ export type ExportType =
   | 'llm-calls'
   | 'embedding-calls'
   | 'errors'
-  | 'sessions';
+  | 'sessions'
+  | 'feedback';
 
 interface ExportDropdownProps {
   filterState: FilterState;
@@ -161,6 +163,11 @@ export function ExportDropdown({ filterState }: ExportDropdownProps) {
       type: 'sessions',
       label: t('monitoring.export.sessions'),
       icon: <Users className="w-4 h-4 mr-2" />,
+    },
+    {
+      type: 'feedback',
+      label: t('monitoring.export.feedback'),
+      icon: <ThumbsUp className="w-4 h-4 mr-2" />,
     },
   ];
 

--- a/web/src/app/home/monitoring/components/FeedbackList.tsx
+++ b/web/src/app/home/monitoring/components/FeedbackList.tsx
@@ -127,6 +127,20 @@ export function FeedbackList({
                         {item.platform}
                       </span>
                     )}
+                    {item.streamId && onViewMessage && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-5 px-1.5 text-xs"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onViewMessage(item.streamId!);
+                        }}
+                      >
+                        <ExternalLink className="w-3 h-3 mr-1" />
+                        {t('monitoring.messageList.viewConversation')}
+                      </Button>
+                    )}
                   </div>
 
                   {item.feedbackContent && (

--- a/web/src/app/home/monitoring/components/FeedbackList.tsx
+++ b/web/src/app/home/monitoring/components/FeedbackList.tsx
@@ -221,21 +221,8 @@ export function FeedbackList({
                         <div className="text-gray-500 dark:text-gray-400">
                           {t('monitoring.feedback.messageId')}
                         </div>
-                        <div className="font-medium text-gray-900 dark:text-white truncate flex items-center gap-1">
-                          <span className="truncate">{item.messageId}</span>
-                          {onViewMessage && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-5 px-1.5 text-xs shrink-0"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onViewMessage(item.messageId!);
-                              }}
-                            >
-                              <ExternalLink className="w-3 h-3" />
-                            </Button>
-                          )}
+                        <div className="font-medium text-gray-900 dark:text-white truncate">
+                          {item.messageId}
                         </div>
                       </div>
                     )}

--- a/web/src/app/home/monitoring/page.tsx
+++ b/web/src/app/home/monitoring/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState, useMemo } from 'react';
+import React, { Suspense, useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
@@ -69,6 +69,9 @@ function MonitoringPageContent() {
     useMonitoringFilters();
   const { data, loading, refetch } = useMonitoringData(filterState);
 
+  // Counter to force feedbackTimeRange recomputation on manual refresh
+  const [feedbackRefreshKey, setFeedbackRefreshKey] = useState(0);
+
   // Get time range for feedback data
   const feedbackTimeRange = useMemo(() => {
     const now = new Date();
@@ -106,7 +109,8 @@ function MonitoringPageContent() {
       startTime: startTime?.toISOString(),
       endTime: endTime.toISOString(),
     };
-  }, [filterState.timeRange, filterState.customDateRange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterState.timeRange, filterState.customDateRange, feedbackRefreshKey]);
 
   // Feedback data hook
   const {
@@ -126,6 +130,12 @@ function MonitoringPageContent() {
     endTime: feedbackTimeRange.endTime,
     limit: 50,
   });
+
+  // Combined refresh handler for both monitoring and feedback data
+  const handleRefresh = useCallback(() => {
+    refetch();
+    setFeedbackRefreshKey((k) => k + 1);
+  }, [refetch]);
 
   const [expandedMessageId, setExpandedMessageId] = useState<string | null>(
     null,
@@ -265,7 +275,7 @@ function MonitoringPageContent() {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={refetch}
+                onClick={handleRefresh}
                 className="shadow-sm flex-shrink-0"
               >
                 <svg

--- a/web/src/i18n/locales/en-US.ts
+++ b/web/src/i18n/locales/en-US.ts
@@ -1163,7 +1163,7 @@ const enUS = {
       contextInfo: 'Context Info',
       userId: 'User ID',
       messageId: 'Message ID',
-      streamId: 'Stream ID',
+      streamId: 'Related Query ID',
       inaccurateReasons: 'Inaccurate Reasons',
       platform: 'Platform',
       exportFeedback: 'Export Feedback',
@@ -1194,6 +1194,7 @@ const enUS = {
       embeddingCalls: 'Embedding Calls',
       errors: 'Error Logs',
       sessions: 'Sessions',
+      feedback: 'User Feedback',
     },
   },
   limitation: {

--- a/web/src/i18n/locales/es-ES.ts
+++ b/web/src/i18n/locales/es-ES.ts
@@ -1193,7 +1193,7 @@ const esES = {
       contextInfo: 'Información de contexto',
       userId: 'ID de usuario',
       messageId: 'ID de mensaje',
-      streamId: 'ID de flujo',
+      streamId: 'ID de consulta relacionada',
       inaccurateReasons: 'Razones de inexactitud',
       platform: 'Plataforma',
       exportFeedback: 'Exportar comentarios',
@@ -1224,6 +1224,7 @@ const esES = {
       embeddingCalls: 'Llamadas Embedding',
       errors: 'Registros de errores',
       sessions: 'Sesiones',
+      feedback: 'Comentarios de usuarios',
     },
   },
   limitation: {

--- a/web/src/i18n/locales/ja-JP.ts
+++ b/web/src/i18n/locales/ja-JP.ts
@@ -1145,7 +1145,7 @@
       contextInfo: 'コンテキスト情報',
       userId: 'ユーザーID',
       messageId: 'メッセージID',
-      streamId: 'ストリームID',
+      streamId: '関連質問ID',
       inaccurateReasons: '不正確な理由',
       platform: 'プラットフォーム',
       exportFeedback: 'フィードバックをエクスポート',
@@ -1167,6 +1167,7 @@
       embeddingCalls: 'Embedding コール',
       errors: 'エラーログ',
       sessions: 'セッション',
+      feedback: 'ユーザーフィードバック',
     },
   },
   limitation: {

--- a/web/src/i18n/locales/th-TH.ts
+++ b/web/src/i18n/locales/th-TH.ts
@@ -1141,7 +1141,7 @@ const thTH = {
       contextInfo: 'ข้อมูลบริบท',
       userId: 'ID ผู้ใช้',
       messageId: 'ID ข้อความ',
-      streamId: 'ID สตรีม',
+      streamId: 'ID คำถามที่เกี่ยวข้อง',
       inaccurateReasons: 'เหตุผลที่ไม่ถูกต้อง',
       platform: 'แพลตฟอร์ม',
       exportFeedback: 'ส่งออกความคิดเห็น',
@@ -1172,6 +1172,7 @@ const thTH = {
       embeddingCalls: 'การเรียก Embedding',
       errors: 'บันทึกข้อผิดพลาด',
       sessions: 'เซสชัน',
+      feedback: 'ความคิดเห็นผู้ใช้',
     },
   },
   limitation: {

--- a/web/src/i18n/locales/vi-VN.ts
+++ b/web/src/i18n/locales/vi-VN.ts
@@ -1162,7 +1162,7 @@ const viVN = {
       contextInfo: 'Thông tin ngữ cảnh',
       userId: 'ID người dùng',
       messageId: 'ID tin nhắn',
-      streamId: 'ID luồng',
+      streamId: 'ID câu hỏi liên quan',
       inaccurateReasons: 'Lý do không chính xác',
       platform: 'Nền tảng',
       exportFeedback: 'Xuất phản hồi',
@@ -1193,6 +1193,7 @@ const viVN = {
       embeddingCalls: 'Cuộc gọi Embedding',
       errors: 'Nhật ký lỗi',
       sessions: 'Phiên',
+      feedback: 'Phản hồi người dùng',
     },
   },
   limitation: {

--- a/web/src/i18n/locales/zh-Hans.ts
+++ b/web/src/i18n/locales/zh-Hans.ts
@@ -1109,7 +1109,7 @@ const zhHans = {
       contextInfo: '上下文信息',
       userId: '用户ID',
       messageId: '消息ID',
-      streamId: '流ID',
+      streamId: '关联提问ID',
       inaccurateReasons: '不准确原因',
       platform: '平台',
       exportFeedback: '导出反馈',
@@ -1140,6 +1140,7 @@ const zhHans = {
       embeddingCalls: 'Embedding 调用',
       errors: '错误日志',
       sessions: '会话记录',
+      feedback: '用户反馈',
     },
   },
   limitation: {

--- a/web/src/i18n/locales/zh-Hant.ts
+++ b/web/src/i18n/locales/zh-Hant.ts
@@ -1085,7 +1085,7 @@ const zhHant = {
       contextInfo: '上下文資訊',
       userId: '使用者ID',
       messageId: '訊息ID',
-      streamId: '串流ID',
+      streamId: '關聯提問ID',
       inaccurateReasons: '不準確原因',
       platform: '平台',
       exportFeedback: '匯出反饋',
@@ -1107,6 +1107,7 @@ const zhHant = {
       embeddingCalls: 'Embedding 呼叫',
       errors: '錯誤日誌',
       sessions: '會話記錄',
+      feedback: '使用者回饋',
     },
   },
   limitation: {


### PR DESCRIPTION
## 概要

基于 #2108 的反馈功能，解决反馈记录中的 `stream_id` 和 `message_id` 无法关联 LangBot 消息记录的问题，并新增前端反馈数据导出入口。

### 问题分析

反馈记录中的 `stream_id`（企微 SDK 临时会话 ID，60 秒过期）和 `message_id`（企微平台 msg_id）在 LangBot 的 `monitoring_messages` 表中没有匹配，是孤立数据。根本原因是：LangBot 消息 ID 在 `pipelinemgr.py` 的 `record_query_start` 中生成，但这个值从未传回给企微适配器，导致反馈到达时无法获取。

### 修改内容

| 文件 | 修改说明 |
|------|---------|
| `src/langbot/pkg/pipeline/pipelinemgr.py` | `record_query_start` 后新增 2 行适配器通知钩子（`on_monitoring_message_created`），通用设计，其他适配器也可实现 |
| `src/langbot/pkg/platform/sources/wecombot.py` | 新增 `_stream_to_monitoring_msg` 映射（10 分钟 TTL 定期清理）、`on_monitoring_message_created` 回调方法、`_on_feedback` 中用 LangBot 消息 ID 替换 `stream_id` |
| `src/langbot/libs/wecom_ai_bot_api/api.py` | `StreamSessionManager.cleanup()` 对已注册 `feedback_id` 的会话使用 10 分钟 TTL（`_FEEDBACK_SESSION_TTL = 600`），与适配器 `_stream_to_monitoring_msg` 对齐 |
| `web/src/app/home/monitoring/components/FeedbackList.tsx` | 移除消息 ID 无效的跳转按钮 |
| `web/src/app/home/monitoring/components/ExportDropdown.tsx` | 新增"用户反馈"导出选项（后端 `export_feedback` 已有完整实现） |
| `web/src/i18n/locales/*.ts`（7 个文件） | `streamId` 标签改为"关联提问ID"等各语言翻译，`export.feedback` 新增翻译 |

### 设计要点

- **pipelinemgr 仅通知，不耦合**：只调 `hasattr(adapter, 'on_monitoring_message_created')`，适配器自行决定如何处理
- **用 `get()` 不用 `pop()`**：点赞改点踩时第二次反馈仍能查到 monitoring_message_id
- **仅替换 `stream_id`，`message_id` 保持企微 msg_id 不变**

---

## 两层映射与 TTL 设计

反馈数据从企微到达 LangBot 数据库，经过两层内存映射，每层各有一个 10 分钟 TTL，解决不同的问题：

### 第一层：`_STREAM_MAPPING_TTL = 600`（wecombot.py）

**解决"stream_id 无法关联 LangBot 消息记录"的问题。**

企微 SDK 的 `stream_id` 是临时 ID，LangBot 的 `monitoring_message_id` 是另一个 UUID，两者完全不同，反馈记录里的 `stream_id` 在 LangBot 的 `monitoring_messages` 表中找不到对应消息。

```
映射字典：企微 stream_id → LangBot monitoring_message_id

写入时机：pipelinemgr 的 record_query_start 后，调用 adapter.on_monitoring_message_created()
使用时机：_on_feedback() 中，用映射把 stream_id 替换成 monitoring_message_id
清理时机：每次写入时顺便清理过期条目，防止内存泄漏
```

### 第二层：`_FEEDBACK_SESSION_TTL = 600`（api.py）

**解决"反馈上下文全部丢失"的问题。**

`StreamSessionManager` 的 `cleanup()` 在每个 POST 回调处理前执行，原 TTL 为 60 秒。流式响应结束后，用户阅读回复 → 点赞 → 取消 → 填写点踩原因，整个过程很容易超过 60 秒。`cleanup()` 在反馈事件处理之前就清除了 session，导致 `get_session_by_feedback_id()` 返回 None，所有上下文字段（`session_id`、`user_id`、`message_id`、`stream_id`）全部丢失。

**修复**：对已注册 `feedback_id` 的 session 使用独立的 10 分钟 TTL。

### 两层的数据流关系

```
反馈事件到达
  │
  ├─ 第二层（api.py）SessionManager 查找 session
  │    session_id = session.chat_id   → "group_xxx"
  │    user_id    = session.user_id   → "zhangsan"
  │    message_id = session.msg_id    → "msg_123"
  │    stream_id  = session.stream_id → "stream_abc"  ← 传给第一层
  │
  └─ 第一层（wecombot.py）适配器查映射字典
       _stream_to_monitoring_msg["stream_abc"] → ("uuid-xxx", timestamp)
       stream_id = monitoring_msg_id or stream_id
                                        → "uuid-xxx"   ← 替换成功
                                                    ↓
                                          FeedbackEvent 写入数据库
                              session_id, user_id, message_id, stream_id 全部完整
```

**为什么两层 TTL 必须对齐：**

- 如果第二层先死（session 60s 过期）→ 拿不到 `stream_id` → 第一层的映射字典根本用不上 → 上下文全丢
- 如果第一层先死（映射过期）→ 有原始 `stream_id`，但映射字典里找不到 → `stream_id` 只能存原始值，无法关联到 LangBot 消息记录
- 两层 10 分钟对齐，确保任意一层不会先于另一层过期

---

## 测试计划

- [x] 发送消息 → 点赞 → 反馈记录 `stream_id` 为 LangBot 消息记录 UUID
- [x] 同一消息点赞改点踩 → `stream_id` 保持 LangBot UUID 不变
- [x] 会话过期（>60s）后反馈仍能正确关联（两层映射均 10 分钟 TTL）
- [x] 点赞 → 取消 → 点踩（填写原因）→ 上下文信息完整记录（session_id、user_id、message_id、stream_id）
- [x] 反馈导出 → 选择"用户反馈"类型 → 下载 CSV 确认包含数据
- [x] ruff format + ruff check 通过