### PR TITLE
fix(provider): ignore empty token rotation

### DIFF
--- a/src/langbot/pkg/provider/modelmgr/token.py
+++ b/src/langbot/pkg/provider/modelmgr/token.py
@@ -30,4 +30,6 @@ class TokenManager:
         return self.tokens[self.using_token_index]
 
     def next_token(self):
+        if len(self.tokens) == 0:
+            return
         self.using_token_index = (self.using_token_index + 1) % len(self.tokens)

--- a/tests/unit_tests/provider/test_model_service.py
+++ b/tests/unit_tests/provider/test_model_service.py
@@ -81,6 +81,15 @@ def test_token_manager_filters_blank_and_duplicate_tokens():
     assert token_mgr.get_token() == 'first-key'
 
 
+def test_token_manager_next_token_ignores_empty_token_list():
+    token_mgr = TokenManager('provider-uuid', [])
+
+    token_mgr.next_token()
+
+    assert token_mgr.get_token() == ''
+    assert token_mgr.using_token_index == 0
+
+
 @pytest.mark.asyncio
 async def test_openai_requester_initialize_uses_placeholder_api_key(monkeypatch):
     captured_kwargs = {}


### PR DESCRIPTION
## Summary

Fixes `TokenManager.next_token()` for providers with no configured API tokens.

## Bug

`get_token()` already treats an empty token list as a valid no-token state by returning an empty string, but `next_token()` attempted modulo by `len(self.tokens)`, raising `ZeroDivisionError` when the list was empty.

Tracked in #2169.

## Changes

- Return early from `next_token()` when no tokens are configured.
- Add a regression test covering empty-token rotation.

## Tests

```bash
uv run ruff check src/langbot/pkg/provider/modelmgr/token.py tests/unit_tests/provider/test_model_service.py --output-format=concise
uv run pytest tests/unit_tests/provider/test_model_service.py -q --tb=short
```
