### PR TITLE
Fix telemetry send task isolation

### DIFF
--- a/src/langbot/pkg/telemetry/telemetry.py
+++ b/src/langbot/pkg/telemetry/telemetry.py
@@ -13,12 +13,11 @@ class TelemetryManager:
         await telemetry.send({ ... })
     """
 
-    send_tasks: list[asyncio.Task] = []
-
     def __init__(self, ap: core_app.Application):
         self.ap = ap
 
         self.telemetry_config = {}
+        self.send_tasks: list[asyncio.Task] = []
 
     async def initialize(self):
         self.telemetry_config = self.ap.instance_config.data.get('space', {})

--- a/tests/unit_tests/test_telemetry.py
+++ b/tests/unit_tests/test_telemetry.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from langbot.pkg.telemetry.telemetry import TelemetryManager
+
+
+@pytest.mark.asyncio
+async def test_send_tasks_are_scoped_to_manager_instance(monkeypatch):
+    async def fake_send(self, payload):
+        return payload
+
+    monkeypatch.setattr(TelemetryManager, 'send', fake_send)
+
+    first = TelemetryManager(SimpleNamespace())
+    second = TelemetryManager(SimpleNamespace())
+
+    assert first.send_tasks is not second.send_tasks
+
+    await first.start_send_task({'event': 'first'})
+    await first.send_tasks[0]
+
+    assert len(first.send_tasks) == 1
+    assert second.send_tasks == []


### PR DESCRIPTION
## Summary
- Move TelemetryManager send_tasks storage from class state to per-instance state.
- Add a focused regression test to ensure telemetry managers do not share send task lists.

Fixes #2170

## Tests
- uv run ruff check src/langbot/pkg/telemetry/telemetry.py tests/unit_tests/test_telemetry.py
- uv run ruff format --check src/langbot/pkg/telemetry/telemetry.py tests/unit_tests/test_telemetry.py
- uv run pytest tests/unit_tests/test_telemetry.py