### PR TITLE
fix(core): handle SIGINT before app startup

### DIFF
--- a/src/langbot/pkg/core/boot.py
+++ b/src/langbot/pkg/core/boot.py
@@ -46,12 +46,14 @@ async def make_app(loop: asyncio.AbstractEventLoop) -> app.Application:
 
 
 async def main(loop: asyncio.AbstractEventLoop):
+    app_inst: app.Application | None = None
     try:
         # Hang system signal processing
         import signal
 
         def signal_handler(sig, frame):
-            app_inst.dispose()
+            if app_inst is not None:
+                app_inst.dispose()
             print('[Signal] Program exit.')
             os._exit(0)
 

--- a/tests/unit_tests/core/test_boot.py
+++ b/tests/unit_tests/core/test_boot.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import signal
+from types import SimpleNamespace
+
+import pytest
+
+from langbot.pkg.core import boot
+
+
+@pytest.mark.asyncio
+async def test_main_signal_handler_handles_sigint_before_app_created(monkeypatch):
+    captured_handler = {}
+
+    def fake_signal(sig, handler):
+        captured_handler[sig] = handler
+
+    async def fake_make_app(loop):
+        captured_handler[signal.SIGINT](signal.SIGINT, None)
+
+    def fake_exit(code):
+        raise SystemExit(code)
+
+    monkeypatch.setattr(signal, 'signal', fake_signal)
+    monkeypatch.setattr(boot, 'make_app', fake_make_app)
+    monkeypatch.setattr(boot.os, '_exit', fake_exit)
+
+    with pytest.raises(SystemExit) as exc_info:
+        await boot.main(SimpleNamespace())
+
+    assert exc_info.value.code == 0
+
+
+@pytest.mark.asyncio
+async def test_main_signal_handler_disposes_created_app(monkeypatch):
+    captured_handler = {}
+    app_inst = SimpleNamespace(disposed=False)
+
+    def fake_signal(sig, handler):
+        captured_handler[sig] = handler
+
+    def dispose():
+        app_inst.disposed = True
+
+    async def run():
+        captured_handler[signal.SIGINT](signal.SIGINT, None)
+
+    async def fake_make_app(loop):
+        app_inst.dispose = dispose
+        app_inst.run = run
+        return app_inst
+
+    def fake_exit(code):
+        raise SystemExit(code)
+
+    monkeypatch.setattr(signal, 'signal', fake_signal)
+    monkeypatch.setattr(boot, 'make_app', fake_make_app)
+    monkeypatch.setattr(boot.os, '_exit', fake_exit)
+
+    with pytest.raises(SystemExit) as exc_info:
+        await boot.main(SimpleNamespace())
+
+    assert exc_info.value.code == 0
+    assert app_inst.disposed is True


### PR DESCRIPTION
## Summary

Fixes SIGINT handling during startup before the application instance has been created.

## Bug

`boot.main()` registered a signal handler that closed over `app_inst` before `app_inst` was assigned. A SIGINT delivered between signal registration and `make_app()` completion could raise a `NameError` instead of exiting cleanly.

Tracked in #2168.

## Changes

- Initialize `app_inst` to `None` before registering the handler.
- Only call `dispose()` when an application instance has been created.
- Add regression coverage for SIGINT before and after app creation.

## Tests

```bash
uv run ruff check src/langbot/pkg/core/boot.py tests/unit_tests/core/test_boot.py --output-format=concise
uv run pytest tests/unit_tests/core/test_boot.py -q --tb=short
```
