### PR TITLE
fix(pipeline): handle empty longtext response chain

### DIFF
--- a/src/langbot/pkg/pipeline/longtext/longtext.py
+++ b/src/langbot/pkg/pipeline/longtext/longtext.py
@@ -76,6 +76,10 @@ class LongTextProcessStage(stage.PipelineStage):
             self.ap.logger.debug('Long message processing strategy is not set, skip long message processing.')
             return entities.StageProcessResult(result_type=entities.ResultType.CONTINUE, new_query=query)
 
+        if not query.resp_message_chain:
+            self.ap.logger.debug('Response message chain is empty, skip long message processing.')
+            return entities.StageProcessResult(result_type=entities.ResultType.CONTINUE, new_query=query)
+
         # 检查是否包含非 Plain 组件
         contains_non_plain = False
 

--- a/tests/unit_tests/pipeline/test_longtext.py
+++ b/tests/unit_tests/pipeline/test_longtext.py
@@ -1,0 +1,39 @@
+"""
+LongTextProcessStage unit tests
+"""
+
+from importlib import import_module
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def get_modules():
+    """Lazy import to ensure proper initialization order"""
+    longtext = import_module('langbot.pkg.pipeline.longtext.longtext')
+    entities = import_module('langbot.pkg.pipeline.entities')
+    return longtext, entities
+
+
+@pytest.mark.asyncio
+async def test_empty_response_message_chain_continues_without_processing(mock_app, sample_query):
+    """Empty response chains should be a no-op for long text processing."""
+    longtext, entities = get_modules()
+
+    sample_query.resp_message_chain = []
+    sample_query.pipeline_config = {
+        'output': {
+            'long-text-processing': {
+                'threshold': 1,
+            },
+        },
+    }
+
+    stage = longtext.LongTextProcessStage(mock_app)
+    stage.strategy_impl = AsyncMock()
+
+    result = await stage.process(sample_query, 'LongTextProcessStage')
+
+    assert result.result_type == entities.ResultType.CONTINUE
+    assert result.new_query == sample_query
+    stage.strategy_impl.process.assert_not_called()


### PR DESCRIPTION
## Summary
- Skip LongTextProcessStage processing when resp_message_chain is empty or unset
- Add a regression test covering the empty response chain no-op behavior

Fixes #2175

## Tests
- uv run pytest tests/unit_tests/pipeline/test_longtext.py
- uv run ruff check src/langbot/pkg/pipeline/longtext/longtext.py tests/unit_tests/pipeline/test_longtext.py