### PR TITLE
fix: load persisted plugin config

### DIFF
--- a/src/langbot/pkg/api/http/controller/groups/plugins.py
+++ b/src/langbot/pkg/api/http/controller/groups/plugins.py
@@ -7,8 +7,10 @@ import httpx
 import uuid
 import os
 import posixpath
+import sqlalchemy
 
 from .....core import taskmgr
+from .....entity.persistence import plugin as persistence_plugin
 from .. import group
 from langbot_plugin.runtime.plugin.mgr import PluginInstallSource
 
@@ -148,7 +150,15 @@ class PluginsRouterGroup(group.RouterGroup):
                 return self.http_status(404, -1, 'plugin not found')
 
             if quart.request.method == 'GET':
-                return self.success(data={'config': plugin['plugin_config']})
+                result = await self.ap.persistence_mgr.execute_async(
+                    sqlalchemy.select(persistence_plugin.PluginSetting.config)
+                    .where(persistence_plugin.PluginSetting.plugin_author == author)
+                    .where(persistence_plugin.PluginSetting.plugin_name == plugin_name)
+                )
+                persisted_config = result.scalar_one_or_none()
+
+                config = persisted_config if persisted_config is not None else plugin['plugin_config']
+                return self.success(data={'config': config})
             elif quart.request.method == 'PUT':
                 data = await quart.request.json
 


### PR DESCRIPTION
## Summary

Fix plugin configuration reads so the WebUI loads the persisted configuration from the database instead of relying on the runtime plugin info payload, which can still expose the plugin's default config.

## Changes

- Query `PluginSetting.config` directly in `GET /api/v1/plugins/{author}/{plugin_name}/config`
- Keep the previous runtime-provided config as a fallback when no persisted setting exists

## Testing

- `uv run ruff check src/langbot/pkg/api/http/controller/groups/plugins.py`
- `uv run pytest tests/unit_tests/plugin/test_handler_actions.py::TestGetPluginSettings tests/unit_tests/plugin/test_connector_methods.py::TestSetPluginConfig -q`

Fixes langbot-app/LangBot#2207