### PR TITLE
feat(aiocqhttp): handle json type messages in message converter

### DIFF
--- a/src/langbot/pkg/platform/sources/aiocqhttp.py
+++ b/src/langbot/pkg/platform/sources/aiocqhttp.py
@@ -296,39 +296,27 @@ class AiocqhttpMessageConverter(abstract_platform_adapter.AbstractMessageConvert
                 yiri_msg_list.append(platform_message.Face(face_type='dice', face_id=int(face_id), face_name='骰子'))
             elif msg.type == 'json':
                 try:
-                    # `msg.data['data']` may already be a dict in some implementations, or a JSON string in others
                     raw = msg.data.get('data', {})
-                    if isinstance(raw, (dict, list)):
-                        inner_data = raw
-                    else:
-                        try:
-                            inner_data = json.loads(raw or '{}')
-                        except Exception:
-                            inner_data = {}
-
-                    # Try to parse QQ mini-program / Bilibili share cards
-                    app_name = inner_data.get('app', '') if isinstance(inner_data, dict) else ''
-                    if app_name == 'com.tencent.miniapp_01':
-                        detail = inner_data.get('meta', {})
-                        # Some implementations nest details under detail_1
-                        detail_1 = detail.get('detail_1') if isinstance(detail, dict) else None
-                        detail_block = detail_1 if isinstance(detail_1, dict) else detail
-                        title = (
-                            detail_block.get('desc', '分享小程序') if isinstance(detail_block, dict) else '分享小程序'
-                        )
-                        qqdocurl = detail_block.get('qqdocurl', '') if isinstance(detail_block, dict) else ''
-
-                        if qqdocurl:
-                            clean_url = qqdocurl.split('?')[0]
-                            text_content = f'[小程序:{title}] {clean_url}'
-                            yiri_msg_list.append(platform_message.Plain(text=text_content))
+                    if isinstance(raw, str):
+                        raw = json.loads(raw)
+                    if isinstance(raw, dict):
+                        _meta = raw.get('meta', {}) or {}
+                        if isinstance(_meta, dict):
+                            _detail = _meta.get('detail_1') or _meta.get('music') or _meta.get('news') or {}
                         else:
-                            yiri_msg_list.append(platform_message.Plain(text=f'[小程序:{title}]'))
+                            _detail = {}
+                        if isinstance(_detail, dict):
+                            preview = _detail.get('preview', '')
+                            title = _detail.get('desc', '') or _detail.get('title', '')
+                            url = _detail.get('qqdocurl', '') or _detail.get('jumpUrl', '')
+                        else:
+                            preview = title = url = ''
+                        text = ' '.join([f'[{raw.get("app", "")}]', preview, title, url]).strip()
+                        yiri_msg_list.append(platform_message.Plain(text=text or '[收到一张JSON卡片]'))
                     else:
-                        # Fallback for unknown JSON card types
-                        yiri_msg_list.append(platform_message.Plain(text='[收到一张JSON卡片]'))
-                except Exception as e:
-                    print(f'解析 JSON 消息失败: {e}')
+                        yiri_msg_list.append(platform_message.Plain(text=str(raw)))
+                except Exception:
+                    yiri_msg_list.append(platform_message.Plain(text='[收到一张JSON卡片]'))
 
         chain = platform_message.MessageChain(yiri_msg_list)
 

--- a/src/langbot/pkg/platform/sources/aiocqhttp.py
+++ b/src/langbot/pkg/platform/sources/aiocqhttp.py
@@ -3,6 +3,7 @@ import typing
 import asyncio
 import traceback
 import datetime
+import json
 
 import aiocqhttp
 import pydantic
@@ -293,6 +294,41 @@ class AiocqhttpMessageConverter(abstract_platform_adapter.AbstractMessageConvert
             elif msg.type == 'dice':
                 face_id = msg.data['result']
                 yiri_msg_list.append(platform_message.Face(face_type='dice', face_id=int(face_id), face_name='骰子'))
+            elif msg.type == 'json':
+                try:
+                    # `msg.data['data']` may already be a dict in some implementations, or a JSON string in others
+                    raw = msg.data.get('data', {})
+                    if isinstance(raw, (dict, list)):
+                        inner_data = raw
+                    else:
+                        try:
+                            inner_data = json.loads(raw or '{}')
+                        except Exception:
+                            inner_data = {}
+
+                    # Try to parse QQ mini-program / Bilibili share cards
+                    app_name = inner_data.get('app', '') if isinstance(inner_data, dict) else ''
+                    if app_name == 'com.tencent.miniapp_01':
+                        detail = inner_data.get('meta', {})
+                        # Some implementations nest details under detail_1
+                        detail_1 = detail.get('detail_1') if isinstance(detail, dict) else None
+                        detail_block = detail_1 if isinstance(detail_1, dict) else detail
+                        title = (
+                            detail_block.get('desc', '分享小程序') if isinstance(detail_block, dict) else '分享小程序'
+                        )
+                        qqdocurl = detail_block.get('qqdocurl', '') if isinstance(detail_block, dict) else ''
+
+                        if qqdocurl:
+                            clean_url = qqdocurl.split('?')[0]
+                            text_content = f'[小程序:{title}] {clean_url}'
+                            yiri_msg_list.append(platform_message.Plain(text=text_content))
+                        else:
+                            yiri_msg_list.append(platform_message.Plain(text=f'[小程序:{title}]'))
+                    else:
+                        # Fallback for unknown JSON card types
+                        yiri_msg_list.append(platform_message.Plain(text='[收到一张JSON卡片]'))
+                except Exception as e:
+                    print(f'解析 JSON 消息失败: {e}')
 
         chain = platform_message.MessageChain(yiri_msg_list)
 


### PR DESCRIPTION
Add support for parsing OneBot JSON message segments (QQ mini-program, Bilibili share cards, etc.) in the target2yiri converter. Parses the card metadata and converts it to plain text to avoid silently dropping these message types.

## 概述 / Overview

> 请在此部分填写你实现/解决/优化的内容:  
> Summary of what you implemented/solved/optimized:
> 

### 更改前后对比截图 / Screenshots

> 请在此部分粘贴更改前后对比截图（可以是界面截图、控制台输出、对话截图等）:  
> Please paste the screenshots of changes before and after here (can be interface screenshots, console output, conversation screenshots, etc.):
> 
> 修改前 / Before:

无OneBotV11的json解析
> 
> 修改后 / After:
> 
 Plain('[小程序:【花笺】更加现代化的Windows便签软件！] https://b23.tv/IugrTwm')]))

不知道格式是否合理，要大佬审核

## 检查清单 / Checklist

### PR 作者完成 / For PR author

*请在方括号间写`x`以打勾 / Please tick the box with `x`*

- [ ] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
- [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
- [x] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.

### 项目维护者完成 / For project maintainer

- [ ] 相关 issues 链接了吗？ / Have you linked the related issues?
- [x] 配置项写好了吗？迁移写好了吗？生效了吗？ / Have you written the configuration items? Have you written the migration? Has it taken effect?
- [ ] 依赖加到 pyproject.toml 和 core/bootutils/deps.py 了吗 / Have you added the dependencies to pyproject.toml and core/bootutils/deps.py?
- [ ] 文档编写了吗？ / Have you written the documentation?