### PR TITLE
feat: add Contributor License Agreement (CLA) and signing workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 *请在方括号间写`x`以打勾 / Please tick the box with `x`*
 
 - [ ] 阅读仓库[贡献指引](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)了吗？ / Have you read the [contribution guide](https://github.com/langbot-app/LangBot/blob/master/CONTRIBUTING.md)?
+- [ ] 我已签署或将在机器人提示后签署 [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。 / I have signed, or will sign when prompted by the bot, the [CLA](https://github.com/langbot-app/LangBot/blob/master/CLA.md).
 - [ ] 与项目所有者沟通过了吗？ / Have you communicated with the project maintainer?
 - [ ] 我确定已自行测试所作的更改，确保功能符合预期。 / I have tested the changes and ensured they work as expected.
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,41 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write          # re-run the failed CLA check after signing
+  contents: read          # signatures are stored in the remote langbot-app/cla repo
+  pull-requests: write    # post guidance comments, lock PR after merge
+  statuses: write         # set the commit status
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Upstream repo was archived in 2026-03; pin to the v2.6.1 commit SHA.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # repo-scope PAT with write access to langbot-app/cla
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          path-to-document: 'https://github.com/langbot-app/LangBot/blob/master/CLA.md'
+          remote-organization-name: 'langbot-app'
+          remote-repository-name: 'cla'
+          path-to-signatures: 'signatures/version1/cla.json'
+          branch: 'main'
+          allowlist: 'dependabot[bot],github-actions[bot],devin-ai-integration[bot],Copilot,renovate[bot],bot*'
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! :heart: Before we can merge this pull request, we need you to sign the [LangBot Contributor License Agreement (CLA)](https://github.com/langbot-app/LangBot/blob/master/CLA.md). You keep full copyright of your code — the CLA grants us a license to use and distribute your contribution. Signing takes 10 seconds and covers all repositories in this organization, permanently.
+
+            感谢您的贡献！合并前请阅读并签署[贡献者许可协议（CLA）](https://github.com/langbot-app/LangBot/blob/master/CLA.md)。您保留代码的全部版权，签署仅需回复下方指定内容，一次签署对本组织全部仓库永久有效。
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. :white_check_mark: 所有贡献者均已签署 CLA。'
+          lock-pullrequest-aftermerge: true
+        # SECURITY: this workflow runs on pull_request_target (it holds secrets and has
+        # write access to the base repository). NEVER add an actions/checkout step that
+        # checks out the PR's code here.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,107 @@
+# LangBot Individual Contributor License Agreement (v1.0)
+
+Thank you for your interest in contributing to LangBot (the "Project"), stewarded by Beijing Langbo Intelligent Technology Co., Ltd. (北京浪波智能科技有限公司) ("We" or "Us").
+
+This Individual Contributor License Agreement ("Agreement") documents the rights granted by contributors to Us. By signing this Agreement (see Section 9), You accept and agree to the following terms and conditions for Your present and future Contributions submitted to the Project. Except for the licenses granted herein to Us and recipients of software distributed by Us, You reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Us.
+
+"Contribution" shall mean any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Us for inclusion in, or documentation of, any of the products or repositories owned or managed by Us (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to Us or our representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works. For clarity, this includes the right for Us to distribute Your Contributions, alone or as part of the Work, under the terms of any license, including without limitation open source licenses and commercial or proprietary licenses.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us and to recipients of software distributed by Us a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which You have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+
+## 4. Authority; Employer
+
+You represent that You are legally entitled to grant the above licenses. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to Us, or that Your employer has executed a separate Corporate Contributor License Agreement with Us.
+
+## 5. Original Creation; Disclosure
+
+You represent that each of Your Contributions is Your original creation (see Section 7 for submissions on behalf of others). You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which You are personally aware and which are associated with any part of Your Contributions.
+
+## 6. No Obligation of Support; Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Third-Party Works
+
+Should You wish to submit work that is not Your original creation, You may submit it to Us separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which You are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+## 8. Notification
+
+You agree to notify Us of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.
+
+## 9. Electronic Signature
+
+This Agreement is accepted and signed electronically: posting a comment containing the exact phrase designated by Us (currently "I have read the CLA Document and I hereby sign the CLA") from Your GitHub account on a pull request in the Project's repositories constitutes Your binding electronic signature to this Agreement. You represent that the GitHub account used to sign belongs to You and that You are of legal age to form a binding contract. Your signature covers Your present and future Contributions to all repositories owned or managed by Us, until and unless You notify Us in writing that You withdraw from this Agreement for future Contributions (licenses already granted are irrevocable).
+
+## 10. Our Commitment
+
+We commit that the Project's main repository will continue to make an open source version of the Work publicly available.
+
+## 11. Miscellaneous
+
+This Agreement is the entire agreement between You and Us regarding Your Contributions and supersedes any prior agreements on this subject. If any provision is held unenforceable, the remaining provisions remain in effect. This Agreement is executed in English; the Chinese translation below is provided for reference only, and the English version shall prevail in case of any discrepancy.
+
+---
+
+# LangBot 个人贡献者许可协议（v1.0）中文参考译文
+
+> 本译文仅供参考，如与英文版有任何歧义，以英文版为准。
+
+感谢您有意为 LangBot（下称"本项目"）作出贡献。本项目由北京浪波智能科技有限公司（下称"我方"）运营管理。
+
+本《个人贡献者许可协议》（下称"本协议"）旨在记录贡献者授予我方的各项权利。您一经签署本协议（见第 9 条），即接受并同意以下条款与条件，适用于您向本项目提交的现在及未来的全部贡献。除本协议授予我方及我方分发软件之接收者的许可外，您保留对您的贡献的全部权利、所有权和利益。
+
+## 1. 定义
+
+"您"指与我方订立本协议的版权所有人，或经版权所有人授权的法律实体。
+
+"贡献"指您有意提交给我方、用于纳入我方拥有或管理的任何产品或代码仓库（下称"作品"）或其文档的任何原创作品，包括对既有作品的修改或增补。就本定义而言，"提交"指以任何电子、口头或书面形式向我方或我方代表发送的通信，包括但不限于在由我方或代表我方管理的电子邮件列表、源代码管理系统和问题跟踪系统中，为讨论和改进作品而进行的通信；但您以显著方式标注或以书面形式声明为"非贡献"（Not a Contribution）的通信除外。
+
+## 2. 版权许可的授予
+
+在遵守本协议条款与条件的前提下，您特此授予我方及我方分发软件之接收者一项永久的、全球范围的、非独占的、免费的、免版税的、不可撤销的版权许可，以复制您的贡献、基于其创作衍生作品、公开展示、公开表演、再许可以及分发您的贡献及上述衍生作品。为明确起见，上述许可包括我方有权以任何许可条款（包括但不限于开源许可证以及商业或专有许可证）单独或作为作品的一部分分发您的贡献。
+
+## 3. 专利许可的授予
+
+在遵守本协议条款与条件的前提下，您特此授予我方及我方分发软件之接收者一项永久的、全球范围的、非独占的、免费的、免版税的、不可撤销的（本条所述情形除外）专利许可，以制造、委托制造、使用、许诺销售、销售、进口及以其他方式转让作品；该许可仅适用于您可许可的、且因您的贡献本身或您的贡献与其所提交之作品的结合而必然受到侵犯的专利权利要求。如任何实体对您或任何其他实体提起专利诉讼（包括诉讼中的交叉请求或反诉），主张您的贡献或您所贡献的作品构成直接或帮助性专利侵权，则依据本协议就该贡献或作品授予该实体的任何专利许可，自该诉讼提起之日起终止。
+
+## 4. 权利能力与雇主
+
+您声明您在法律上有权授予上述许可。如您的雇主对您创作的、包含您的贡献在内的知识产权享有权利，您声明：您已获得该雇主代表其作出贡献的许可，或该雇主已就您向我方的贡献放弃上述权利，或该雇主已与我方另行签署《企业贡献者许可协议》。
+
+## 5. 原创性声明与披露义务
+
+您声明您的每项贡献均为您的原创作品（代表第三方提交的情形见第 7 条）。您声明您提交的贡献中已完整披露您本人知悉的、与您的贡献任何部分相关的任何第三方许可或其他限制（包括但不限于相关专利和商标）的全部细节。
+
+## 6. 无支持义务；免责声明
+
+您无义务为您的贡献提供支持，除非您自愿提供。您可以免费提供支持、收费提供支持或不提供支持。除非适用法律要求或另有书面约定，您的贡献按"现状"（AS IS）提供，不附带任何明示或默示的保证或条件，包括但不限于关于权属、不侵权、适销性或特定用途适用性的任何保证或条件。
+
+## 7. 第三方作品
+
+如您希望提交非您原创的作品，您可以将其与任何贡献分开单独提交给我方，并完整说明其来源以及您本人知悉的任何许可或其他限制（包括但不限于相关专利、商标和许可协议）的全部细节，同时以显著方式将该作品标注为"代表第三方提交：[此处注明第三方名称]"。
+
+## 8. 通知义务
+
+如您知悉任何事实或情况将导致上述声明在任何方面不准确，您同意通知我方。
+
+## 9. 电子签署
+
+本协议以电子方式接受并签署：您通过您的 GitHub 账号，在本项目代码仓库的拉取请求（pull request）中发表包含我方指定语句（现为 "I have read the CLA Document and I hereby sign the CLA"）的评论，即构成您对本协议具有约束力的电子签名。您声明用于签署的 GitHub 账号归您本人所有，且您已达到订立有约束力合同的法定年龄。您的签署覆盖您对我方拥有或管理的全部代码仓库的现在及未来的贡献，直至您以书面形式通知我方就未来贡献退出本协议为止（已授予的许可不可撤销）。
+
+## 10. 我方承诺
+
+我方承诺本项目主仓库将持续公开提供作品的开源版本。
+
+## 11. 其他
+
+本协议构成您与我方之间就您的贡献达成的完整协议，并取代双方先前就此主题达成的任何协议。如本协议任何条款被认定为不可执行，其余条款仍然有效。本协议以英文签署，中文译文仅供参考，如有歧义以英文版为准。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@
 - 在 PR 和 Commit Message 中请使用全英文
 - 对于中文用户，issue 中可以使用中文
 
+### 贡献者许可协议（CLA）
+
+为了保护项目和每一位贡献者，我们要求所有代码贡献者签署[贡献者许可协议（CLA）](./CLA.md)。这是 Apache、Google、Grafana 等主流开源项目的标准做法：您保留自己代码的全部版权，仅授予项目使用、分发您贡献的许可。
+
+签署只需 10 秒：首次提交 PR 时，机器人会自动评论提示，按提示回复一句话即完成签署，此后对本组织所有仓库永久有效。历史贡献不受影响。
+
 <hr/>
 
 ## Guidelines
@@ -29,3 +35,9 @@
 
 - Use English in PRs and Commit Messages
 - For English users, you can use English in issues
+
+### Contributor License Agreement (CLA)
+
+To protect the project and every contributor, we require all code contributors to sign our [Contributor License Agreement](./CLA.md). This is standard practice in major open source projects such as Apache, Google, and Grafana: you keep full copyright of your code — the CLA only grants us a license to use and distribute your contribution.
+
+Signing takes 10 seconds: when you open your first PR, a bot will guide you to reply with a single comment. One signature covers all repositories in this organization, permanently. Past contributions are not affected.


### PR DESCRIPTION
## Overview

Introduces a Contributor License Agreement (CLA) system for the LangBot organization:

- **`CLA.md`** — Individual CLA v1.0 (license-grant style, based on Apache ICLA v2.2; contributors keep full copyright). English authoritative text + Chinese reference translation. Grantee: Beijing Langbo Intelligent Technology Co., Ltd. (北京浪波智能科技有限公司).
- **`.github/workflows/cla.yml`** — automated signing via `contributor-assistant/github-action` (pinned to v2.6.1 commit SHA; upstream archived 2026-03). Contributors sign by replying to a bot comment on their first PR (~10 s). Signatures are recorded in [langbot-app/cla](https://github.com/langbot-app/cla) and cover all repositories in the organization. Bot accounts (dependabot, devin-ai-integration, Copilot, etc.) are allowlisted.
- **`CONTRIBUTING.md` / PR template** — bilingual CLA notice.

为组织引入贡献者许可协议体系：许可型（非转让）个人 CLA、PR 内回复一句话即完成签署、签名记录存于 langbot-app/cla 仓库、一次签署全组织通用。存量贡献者的历史贡献不受影响。

## ⚠️ Before merging / 合并前置条件

1. Create a repo-scope PAT (machine account recommended) with **write access to `langbot-app/cla`**, and add it as repository secret **`CLA_PAT`** — otherwise the CLA check will error on every new PR. / 先创建对 `langbot-app/cla` 有写权限的 PAT 并存入仓库 secret `CLA_PAT`，否则合并后所有新 PR 的 CLA 检查会报错。
2. After merging and verifying on a real PR, add the `CLAAssistant` status check to the master ruleset's required checks to enforce signing. / 合并并在真实 PR 上验证后，将 `CLAAssistant` 加入 master 的 required status checks 实现硬约束。

## Security note

The workflow runs on `pull_request_target` and holds secrets. It must never check out PR code — a warning comment is included in the file; please keep an eye on any future modifications to this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)